### PR TITLE
feat: gate evaluator — shell, function, and API gate execution (WOP-1816)

### DIFF
--- a/src/engine/gate-evaluator.ts
+++ b/src/engine/gate-evaluator.ts
@@ -1,0 +1,157 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import Handlebars from "handlebars";
+import type { Entity, Gate } from "../repositories/interfaces.js";
+
+const execFileAsync = promisify(execFile);
+const hbs = Handlebars.create();
+
+export interface GateEvalResult {
+  passed: boolean;
+  output: string;
+}
+
+export function hydrateTemplate(template: string, context: Record<string, unknown>): string {
+  return hbs.compile(template)(context);
+}
+
+export async function evaluateGate(gate: Gate, entity: Entity): Promise<GateEvalResult> {
+  switch (gate.type) {
+    case "command":
+      return evaluateShellGate(gate, entity);
+    case "function":
+      return evaluateFunctionGate(gate, entity);
+    case "api":
+      return evaluateApiGate(gate, entity);
+    default:
+      return { passed: false, output: `Unknown gate type: ${gate.type}` };
+  }
+}
+
+async function evaluateShellGate(gate: Gate, entity: Entity): Promise<GateEvalResult> {
+  if (!gate.command) {
+    return { passed: false, output: "Gate command is not configured" };
+  }
+
+  const context = { entity, gate };
+  const hydrated = hydrateTemplate(gate.command, context);
+
+  try {
+    const { stdout, stderr } = await execFileAsync("/bin/sh", ["-c", hydrated], {
+      timeout: gate.timeoutMs,
+    });
+    return { passed: true, output: (stdout + stderr).trim() };
+  } catch (err: unknown) {
+    const error = err as { killed?: boolean; code?: number; stderr?: string; message?: string };
+    if (error.killed) {
+      return { passed: false, output: `Command timed out after ${gate.timeoutMs}ms` };
+    }
+    return {
+      passed: false,
+      output: (error.stderr ?? error.message ?? "Unknown error").trim(),
+    };
+  }
+}
+
+async function evaluateFunctionGate(gate: Gate, entity: Entity): Promise<GateEvalResult> {
+  if (!gate.functionRef) {
+    return { passed: false, output: "Gate function_ref is not configured" };
+  }
+
+  const colonIndex = gate.functionRef.indexOf(":");
+  if (colonIndex === -1) {
+    return {
+      passed: false,
+      output: `Invalid function_ref format: "${gate.functionRef}" (expected "module_path:export_name")`,
+    };
+  }
+
+  const modulePath = gate.functionRef.slice(0, colonIndex);
+  const exportName = gate.functionRef.slice(colonIndex + 1);
+
+  try {
+    const mod = await import(modulePath);
+    const fn = mod[exportName];
+    if (typeof fn !== "function") {
+      return {
+        passed: false,
+        output: `Export "${exportName}" from "${modulePath}" is not a function`,
+      };
+    }
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error(`Function gate timed out after ${gate.timeoutMs}ms`)), gate.timeoutMs);
+    });
+
+    const result = await Promise.race([fn(entity, gate), timeoutPromise]);
+
+    if (
+      typeof result !== "object" ||
+      result === null ||
+      typeof (result as Record<string, unknown>).passed !== "boolean" ||
+      typeof (result as Record<string, unknown>).output !== "string"
+    ) {
+      return {
+        passed: false,
+        output: "Function gate returned invalid result (expected { passed: boolean, output: string })",
+      };
+    }
+
+    return { passed: (result as GateEvalResult).passed, output: (result as GateEvalResult).output };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { passed: false, output: message };
+  }
+}
+
+async function evaluateApiGate(gate: Gate, entity: Entity): Promise<GateEvalResult> {
+  if (!gate.apiConfig) {
+    return { passed: false, output: "API gate config is not configured" };
+  }
+
+  const config = gate.apiConfig as {
+    url?: string;
+    method?: string;
+    headers?: Record<string, string>;
+    expect_status?: number;
+    body?: string;
+  };
+
+  if (!config.url) {
+    return { passed: false, output: "API gate config missing url" };
+  }
+
+  const context = { entity, gate };
+  const url = hydrateTemplate(config.url, context);
+  const method = config.method ?? "GET";
+  const expectedStatus = config.expect_status ?? 200;
+
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: config.headers,
+      body: config.body ? hydrateTemplate(config.body, context) : undefined,
+      signal: AbortSignal.timeout(gate.timeoutMs),
+    });
+
+    const text = await response.text();
+
+    return {
+      passed: response.status === expectedStatus,
+      output:
+        response.status === expectedStatus
+          ? text.slice(0, 1000)
+          : `Expected status ${expectedStatus}, got ${response.status}: ${text.slice(0, 500)}`,
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (
+      message.includes("aborted") ||
+      message.includes("AbortError") ||
+      (err instanceof Error && err.name === "AbortError")
+    ) {
+      return { passed: false, output: `API gate timed out after ${gate.timeoutMs}ms` };
+    }
+    return { passed: false, output: message };
+  }
+}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,4 +1,6 @@
 // Engine module — state machine, invocation builder, gate evaluator, flow spawner, event emitter
 
+export type { GateEvalResult } from "./gate-evaluator.js";
+export { evaluateGate, hydrateTemplate } from "./gate-evaluator.js";
 export type { ValidationError } from "./state-machine.js";
 export { evaluateCondition, findTransition, validateFlow } from "./state-machine.js";

--- a/tests/engine/fixtures/passing-gate.ts
+++ b/tests/engine/fixtures/passing-gate.ts
@@ -1,0 +1,5 @@
+import type { GateEvalResult } from "../../../src/engine/gate-evaluator.js";
+
+export function check(): GateEvalResult {
+  return { passed: true, output: "all good" };
+}

--- a/tests/engine/fixtures/slow-gate.ts
+++ b/tests/engine/fixtures/slow-gate.ts
@@ -1,0 +1,7 @@
+import type { GateEvalResult } from "../../../src/engine/gate-evaluator.js";
+
+export function check(): Promise<GateEvalResult> {
+  return new Promise(() => {
+    // intentionally never resolves — for timeout testing
+  });
+}

--- a/tests/engine/gate-evaluator.test.ts
+++ b/tests/engine/gate-evaluator.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from "vitest";
+import { evaluateGate, hydrateTemplate } from "../../src/engine/gate-evaluator.js";
+import type { Entity, Gate } from "../../src/repositories/interfaces.js";
+
+const baseEntity: Entity = {
+  id: "e1",
+  flowId: "f1",
+  state: "open",
+  refs: null,
+  artifacts: null,
+  claimedBy: null,
+  claimedAt: null,
+  flowVersion: 1,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function makeGate(overrides: Partial<Gate> = {}): Gate {
+  return {
+    id: "g1",
+    name: "test-gate",
+    type: "command",
+    command: "echo hello",
+    functionRef: null,
+    apiConfig: null,
+    timeoutMs: 5000,
+    ...overrides,
+  };
+}
+
+// ─── hydrateTemplate ───
+
+describe("hydrateTemplate", () => {
+  it("replaces entity placeholders", () => {
+    const result = hydrateTemplate("echo {{entity.id}}", {
+      entity: { id: "e1", state: "open" },
+    });
+    expect(result).toBe("echo e1");
+  });
+
+  it("returns raw string when no placeholders", () => {
+    expect(hydrateTemplate("pnpm test", {})).toBe("pnpm test");
+  });
+});
+
+// ─── evaluateGate — shell ───
+
+describe("evaluateGate — shell", () => {
+  it("passes when command exits 0", async () => {
+    const gate = makeGate({ command: "echo ok" });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(true);
+    expect(result.output).toContain("ok");
+  });
+
+  it("fails when command exits non-zero", async () => {
+    const gate = makeGate({ command: "false" });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+  });
+
+  it("fails with descriptive message when command is null", async () => {
+    const gate = makeGate({ command: null });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toBe("Gate command is not configured");
+  });
+
+  it("fails with descriptive message when command is empty string", async () => {
+    const gate = makeGate({ command: "" });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toBe("Gate command is not configured");
+  });
+
+  it("respects timeout", async () => {
+    const gate = makeGate({ command: "sleep 10", timeoutMs: 100 });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toMatch(/timed out|ETIMEDOUT|killed/i);
+  }, 2000);
+
+  it("hydrates entity placeholders in command", async () => {
+    const gate = makeGate({ command: "echo {{entity.id}}" });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(true);
+    expect(result.output).toContain("e1");
+  });
+});
+
+// ─── evaluateGate — function ───
+
+describe("evaluateGate — function", () => {
+  it("fails when functionRef is null", async () => {
+    const gate = makeGate({ type: "function", command: null, functionRef: null });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toContain("not configured");
+  });
+
+  it("fails when functionRef has no colon separator", async () => {
+    const gate = makeGate({ type: "function", command: null, functionRef: "no-colon" });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toContain("Invalid function_ref format");
+  });
+
+  it("fails when module cannot be imported", async () => {
+    const gate = makeGate({
+      type: "function",
+      command: null,
+      functionRef: "/nonexistent/module.js:check",
+    });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+  });
+
+  it("calls function and returns its result when it passes", async () => {
+    const gate = makeGate({
+      type: "function",
+      command: null,
+      functionRef: new URL("./fixtures/passing-gate.js", import.meta.url).pathname + ":check",
+    });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(true);
+    expect(result.output).toBe("all good");
+  });
+
+  it("respects timeout on slow function", async () => {
+    const gate = makeGate({
+      type: "function",
+      command: null,
+      functionRef: new URL("./fixtures/slow-gate.js", import.meta.url).pathname + ":check",
+      timeoutMs: 50,
+    });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toMatch(/timed out/i);
+  }, 2000);
+});
+
+// ─── evaluateGate — api ───
+
+describe("evaluateGate — api", () => {
+  it("fails when apiConfig is null", async () => {
+    const gate = makeGate({ type: "api", command: null, apiConfig: null });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toContain("not configured");
+  });
+
+  it("fails when apiConfig has no url", async () => {
+    const gate = makeGate({ type: "api", command: null, apiConfig: { method: "GET" } });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toContain("url");
+  });
+
+  it("passes when response status matches expect_status", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve("OK"),
+    }));
+    const gate = makeGate({
+      type: "api",
+      command: null,
+      apiConfig: {
+        url: "http://localhost:9999/health",
+        method: "GET",
+        expect_status: 200,
+      },
+    });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it("fails when response status does not match expect_status", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    }));
+    const gate = makeGate({
+      type: "api",
+      command: null,
+      apiConfig: {
+        url: "http://localhost:9999/health",
+        method: "GET",
+        expect_status: 200,
+      },
+    });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toContain("500");
+    vi.unstubAllGlobals();
+  });
+
+  it("hydrates entity placeholders in URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve("OK"),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const gate = makeGate({
+      type: "api",
+      command: null,
+      apiConfig: {
+        url: "http://localhost:9999/entity/{{entity.id}}",
+        method: "GET",
+        expect_status: 200,
+      },
+    });
+    await evaluateGate(gate, baseEntity);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:9999/entity/e1",
+      expect.any(Object),
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it("respects timeout via AbortSignal", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(
+      () => new Promise((_, reject) => {
+        setTimeout(() => reject(new DOMException("aborted", "AbortError")), 200);
+      }),
+    ));
+    const gate = makeGate({
+      type: "api",
+      command: null,
+      apiConfig: {
+        url: "http://localhost:9999/slow",
+        method: "GET",
+        expect_status: 200,
+      },
+      timeoutMs: 50,
+    });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toMatch(/timed out|aborted/i);
+    vi.unstubAllGlobals();
+  }, 2000);
+});
+
+// ─── evaluateGate — unknown type ───
+
+describe("evaluateGate — unknown type", () => {
+  it("fails with descriptive message for unknown gate type", async () => {
+    const gate = makeGate({ type: "webhook" as string });
+    const result = await evaluateGate(gate, baseEntity);
+    expect(result.passed).toBe(false);
+    expect(result.output).toContain("Unknown gate type");
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1816

- Implements `evaluateGate()` supporting `command` (shell via `execFile`), `function` (dynamic import), and `api` (fetch with AbortSignal) gate types
- Guards against null/empty `gate.command` — returns `{ passed: false, output: "Gate command is not configured" }`
- Uses `execFile("/bin/sh", ["-c", cmd])` to prevent shell injection in the executable path
- All gate types respect `timeout_ms` via `execFile` timeout, `Promise.race`, and `AbortSignal.timeout()` respectively
- Handlebars template hydration for commands and API URLs
- Re-exports `evaluateGate`, `hydrateTemplate`, `GateEvalResult` from `src/engine/index.ts`
- 20 unit tests covering all gate types, edge cases, and timeouts

## Test plan
- [x] `pnpm build` passes (tsc clean)
- [x] `npx vitest run tests/engine/gate-evaluator.test.ts` — 20/20 pass
- [x] `pnpm run check` (biome) passes

Generated with Claude Code

## Summary by Sourcery

Add a gate evaluation engine that can execute shell commands, imported functions, or HTTP APIs with templating and timeouts, and expose it through the engine module.

New Features:
- Introduce a gate evaluator that supports command, function, and API gate types and returns a standardized pass/fail result with output.
- Add Handlebars-based template hydration for gate commands and API URLs/bodies, using entity and gate context.
- Re-export the gate evaluator API, template helper, and result type from the main engine module for external use.

Tests:
- Add comprehensive unit tests for the gate evaluator across command, function, API, timeout, configuration error, and unknown gate type scenarios, including fixture modules for passing and slow function gates.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add gate evaluator to run `command`, `function`, and `api` gates with timeouts and return standardized `GateEvalResult` in [gate-evaluator.ts](https://github.com/wopr-network/defcon/pull/12/files#diff-2fbba9489ac39de7e98310890772c5fbfce792a6bef32e5a728095adb709c937) for WOP-1816
> Introduce `evaluateGate` with dispatch to `evaluateShellGate`, `evaluateFunctionGate`, and `evaluateApiGate`; add `GateEvalResult` and `hydrateTemplate`; and re-export from [index.ts](https://github.com/wopr-network/defcon/pull/12/files#diff-b6e2a0446ff95e214d3bbcd0796dc7319e6b2f43ce71b4c299cc43ae17d2b674).
>
> #### 🖇️ Linked Issues
> Implements WOP-1816 by adding gate execution support and a standard result shape.
>
> #### 📍Where to Start
> Start with `evaluateGate` in [gate-evaluator.ts](https://github.com/wopr-network/defcon/pull/12/files#diff-2fbba9489ac39de7e98310890772c5fbfce792a6bef32e5a728095adb709c937); then review `evaluateShellGate`, `evaluateFunctionGate`, and `evaluateApiGate`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 55fe65a. 2 files reviewed, 5 issues evaluated, 0 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->