### PR TITLE
feat: invocation builder — Handlebars hydration + ref resolution (WOP-1815)

### DIFF
--- a/src/engine/handlebars.ts
+++ b/src/engine/handlebars.ts
@@ -1,0 +1,33 @@
+import Handlebars from "handlebars";
+
+const hbs = Handlebars.create();
+
+hbs.registerHelper("gt", (a: number, b: number) => (a > b ? "true" : ""));
+hbs.registerHelper("lt", (a: number, b: number) => (a < b ? "true" : ""));
+hbs.registerHelper("eq", (a: unknown, b: unknown) => (String(a) === String(b) ? "true" : ""));
+
+hbs.registerHelper("invocation_count", (entity: { invocations?: { stage: string }[] }, stage: string) =>
+  String(entity.invocations?.filter((i) => i.stage === stage).length ?? 0),
+);
+
+hbs.registerHelper("gate_passed", (entity: { gateResults?: { gate: string; passed: boolean }[] }, gateName: string) =>
+  (entity.gateResults?.some((g) => g.gate === gateName && g.passed) ?? false) ? "true" : "",
+);
+
+hbs.registerHelper("has_artifact", (entity: { artifacts?: Record<string, unknown> }, key: string) =>
+  entity.artifacts?.[key] !== undefined ? "true" : "",
+);
+
+hbs.registerHelper("time_in_state", (entity: { updatedAt: string | Date }) =>
+  String(Date.now() - new Date(entity.updatedAt).getTime()),
+);
+
+/** Get the shared Handlebars instance with all built-in helpers. */
+export function getHandlebars(): typeof hbs {
+  return hbs;
+}
+
+/** Register a custom helper on the shared instance. */
+export function registerHelper(name: string, fn: (...args: unknown[]) => unknown): void {
+  hbs.registerHelper(name, fn);
+}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -2,5 +2,7 @@
 
 export type { GateEvalResult } from "./gate-evaluator.js";
 export { evaluateGate, hydrateTemplate } from "./gate-evaluator.js";
+export { getHandlebars, registerHelper } from "./handlebars.js";
+export { buildInvocation, hydrateGateCommand } from "./invocation-builder.js";
 export type { ValidationError } from "./state-machine.js";
 export { evaluateCondition, findTransition, validateFlow } from "./state-machine.js";

--- a/src/engine/invocation-builder.ts
+++ b/src/engine/invocation-builder.ts
@@ -1,0 +1,83 @@
+import type { Entity, Gate, State } from "../repositories/interfaces.js";
+import { getHandlebars } from "./handlebars.js";
+
+/**
+ * Build an invocation prompt by resolving refs, assembling context, and hydrating the template.
+ *
+ * @param entity      The runtime entity
+ * @param state       The state definition (contains promptTemplate, agentRole, etc.)
+ * @param adapters    Map of adapter name -> adapter instance (each must have `.get(id)`)
+ * @param invocations Optional array of prior invocations (each with `.stage`) for metadata
+ */
+interface Adapter {
+  get(id: string): Promise<unknown>;
+}
+
+export async function buildInvocation(
+  entity: Entity,
+  state: State,
+  adapters: Map<string, Adapter>,
+  invocations: { stage: string }[] = [],
+): Promise<{ prompt: string; context: Record<string, unknown> }> {
+  const hbs = getHandlebars();
+
+  // 1. Local artifacts
+  const artifacts: Record<string, unknown> = entity.artifacts ?? {};
+
+  // 2. Resolve refs
+  const refs: Record<string, unknown> = {};
+  if (entity.refs) {
+    const entries = Object.entries(entity.refs);
+    await Promise.all(
+      entries.map(async ([key, ref]) => {
+        const adapter = adapters.get(ref.adapter);
+        if (!adapter) return;
+        try {
+          refs[key] = await adapter.get(ref.id);
+        } catch {
+          // skip failed ref resolution
+        }
+      }),
+    );
+  }
+
+  // 3. Pipeline metadata
+  const invocationCount = invocations.filter((i) => i.stage === state.name).length;
+  const totalInvocations = invocations.length;
+  const timeInState = Date.now() - new Date(entity.updatedAt).getTime();
+
+  // 4. Assemble context
+  const context: Record<string, unknown> = {
+    artifacts,
+    refs,
+    agent_role: state.agentRole ?? null,
+    invocation_count: invocationCount,
+    total_invocations: totalInvocations,
+    time_in_state: timeInState,
+    entity: {
+      ...entity,
+      invocations,
+      gateResults: [],
+    },
+  };
+
+  // 5. Compile + execute template
+  if (!state.promptTemplate) {
+    return { prompt: "", context };
+  }
+
+  const template = hbs.compile(state.promptTemplate);
+  const prompt = template(context);
+
+  return { prompt, context };
+}
+
+/**
+ * Hydrate a gate's command template with the given context.
+ */
+export function hydrateGateCommand(gate: Gate, context: Record<string, unknown>): string {
+  if (!gate.command) return "";
+  const hbs = getHandlebars();
+  const template = hbs.compile(gate.command);
+  return template(context);
+}

--- a/src/engine/state-machine.ts
+++ b/src/engine/state-machine.ts
@@ -1,29 +1,7 @@
-import Handlebars from "handlebars";
 import type { Flow, Transition } from "../repositories/interfaces.js";
+import { getHandlebars } from "./handlebars.js";
 
-// ─── Shared Handlebars Instance ───
-
-const hbs = Handlebars.create();
-
-hbs.registerHelper("gt", (a: number, b: number) => (a > b ? "true" : ""));
-hbs.registerHelper("lt", (a: number, b: number) => (a < b ? "true" : ""));
-hbs.registerHelper("eq", (a: unknown, b: unknown) => (String(a) === String(b) ? "true" : ""));
-
-hbs.registerHelper("invocation_count", (entity: { invocations?: { stage: string }[] }, stage: string) =>
-  String(entity.invocations?.filter((i) => i.stage === stage).length ?? 0),
-);
-
-hbs.registerHelper("gate_passed", (entity: { gateResults?: { gate: string; passed: boolean }[] }, gateName: string) =>
-  (entity.gateResults?.some((g) => g.gate === gateName && g.passed) ?? false) ? "true" : "",
-);
-
-hbs.registerHelper("has_artifact", (entity: { artifacts?: Record<string, unknown> }, key: string) =>
-  entity.artifacts?.[key] !== undefined ? "true" : "",
-);
-
-hbs.registerHelper("time_in_state", (entity: { updatedAt: string | Date }) =>
-  String(Date.now() - new Date(entity.updatedAt).getTime()),
-);
+const hbs = getHandlebars();
 
 // ─── Condition Evaluation ───
 
@@ -52,7 +30,7 @@ export function findTransition(
 
   for (const candidate of candidates) {
     if (candidate.gateId !== null) {
-      const entity = context["entity"] as { gateResults?: { gate: string; passed: boolean }[] } | undefined;
+      const entity = context.entity as { gateResults?: { gate: string; passed: boolean }[] } | undefined;
       const gatePassed = entity?.gateResults?.some((g) => g.gate === candidate.gateId && g.passed) ?? false;
       if (!gatePassed) continue;
     }

--- a/tests/engine/handlebars.test.ts
+++ b/tests/engine/handlebars.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { getHandlebars, registerHelper } from "../../src/engine/handlebars.js";
+
+describe("getHandlebars", () => {
+  it("returns a Handlebars instance with built-in helpers", () => {
+    const hbs = getHandlebars();
+    expect(hbs).toBeDefined();
+    expect(typeof hbs.compile).toBe("function");
+  });
+
+  it("returns the same instance on repeated calls", () => {
+    expect(getHandlebars()).toBe(getHandlebars());
+  });
+
+  it("has gt helper registered", () => {
+    const hbs = getHandlebars();
+    const tpl = hbs.compile("{{gt a b}}");
+    expect(tpl({ a: 10, b: 5 })).toBe("true");
+    expect(tpl({ a: 3, b: 5 })).toBe("");
+  });
+
+  it("has lt helper registered", () => {
+    const hbs = getHandlebars();
+    const tpl = hbs.compile("{{lt a b}}");
+    expect(tpl({ a: 3, b: 5 })).toBe("true");
+    expect(tpl({ a: 10, b: 5 })).toBe("");
+  });
+
+  it("has eq helper registered", () => {
+    const hbs = getHandlebars();
+    const tpl = hbs.compile("{{eq a b}}");
+    expect(tpl({ a: "x", b: "x" })).toBe("true");
+    expect(tpl({ a: "x", b: "y" })).toBe("");
+  });
+
+  it("has invocation_count helper registered", () => {
+    const hbs = getHandlebars();
+    const tpl = hbs.compile('{{invocation_count entity "review"}}');
+    expect(tpl({ entity: { invocations: [{ stage: "review" }, { stage: "build" }] } })).toBe("1");
+  });
+
+  it("has gate_passed helper registered", () => {
+    const hbs = getHandlebars();
+    const tpl = hbs.compile('{{gate_passed entity "lint"}}');
+    expect(tpl({ entity: { gateResults: [{ gate: "lint", passed: true }] } })).toBe("true");
+  });
+
+  it("has has_artifact helper registered", () => {
+    const hbs = getHandlebars();
+    const tpl = hbs.compile('{{has_artifact entity "diff"}}');
+    expect(tpl({ entity: { artifacts: { diff: "data" } } })).toBe("true");
+  });
+
+  it("has time_in_state helper registered", () => {
+    const hbs = getHandlebars();
+    const tpl = hbs.compile("{{time_in_state entity}}");
+    const result = tpl({ entity: { updatedAt: new Date(Date.now() - 5000).toISOString() } });
+    expect(Number(result)).toBeGreaterThanOrEqual(4000);
+  });
+});
+
+describe("registerHelper", () => {
+  it("registers a custom helper on the shared instance", () => {
+    registerHelper("double", (n: number) => String(n * 2));
+    const hbs = getHandlebars();
+    const tpl = hbs.compile("{{double val}}");
+    expect(tpl({ val: 7 })).toBe("14");
+  });
+});

--- a/tests/engine/invocation-builder.test.ts
+++ b/tests/engine/invocation-builder.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { buildInvocation, hydrateGateCommand } from "../../src/engine/invocation-builder.js";
+import type { Entity, State, Gate } from "../../src/repositories/interfaces.js";
+
+function makeEntity(overrides: Partial<Entity> = {}): Entity {
+  return {
+    id: "e1",
+    flowId: "f1",
+    state: "review",
+    refs: null,
+    artifacts: null,
+    claimedBy: null,
+    claimedAt: null,
+    flowVersion: 1,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date(Date.now() - 10000),
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<State> = {}): State {
+  return {
+    id: "s1",
+    flowId: "f1",
+    name: "review",
+    agentRole: "reviewer",
+    modelTier: "sonnet",
+    mode: "passive",
+    promptTemplate: "Review {{artifacts.diff}} as {{agent_role}}",
+    constraints: null,
+    ...overrides,
+  };
+}
+
+describe("buildInvocation", () => {
+  it("hydrates prompt template with artifacts and metadata", async () => {
+    const entity = makeEntity({ artifacts: { diff: "file.ts +1 -1" } });
+    const state = makeState();
+    const result = await buildInvocation(entity, state, new Map());
+    expect(result.prompt).toBe("Review file.ts +1 -1 as reviewer");
+    expect(result.context.agent_role).toBe("reviewer");
+    expect(result.context.artifacts).toEqual({ diff: "file.ts +1 -1" });
+  });
+
+  it("returns empty prompt when promptTemplate is null", async () => {
+    const entity = makeEntity();
+    const state = makeState({ promptTemplate: null });
+    const result = await buildInvocation(entity, state, new Map());
+    expect(result.prompt).toBe("");
+  });
+
+  it("resolves refs via adapters", async () => {
+    const entity = makeEntity({
+      refs: {
+        issue: { adapter: "linear", id: "ISS-1" },
+        pr: { adapter: "github", id: "42" },
+      },
+    });
+    const state = makeState({ promptTemplate: "Issue: {{refs.issue.title}}" });
+    const adapters = new Map<string, { get: (id: string) => Promise<unknown> }>([
+      ["linear", { get: async (id: string) => ({ id, title: "Fix bug" }) }],
+      ["github", { get: async (id: string) => ({ id, number: 42 }) }],
+    ]);
+    const result = await buildInvocation(entity, state, adapters);
+    expect(result.prompt).toBe("Issue: Fix bug");
+    expect(result.context.refs.issue.title).toBe("Fix bug");
+    expect(result.context.refs.pr.number).toBe(42);
+  });
+
+  it("skips refs when entity.refs is null", async () => {
+    const entity = makeEntity({ refs: null });
+    const state = makeState({ promptTemplate: "No refs" });
+    const result = await buildInvocation(entity, state, new Map());
+    expect(result.prompt).toBe("No refs");
+    expect(result.context.refs).toEqual({});
+  });
+
+  it("skips ref when adapter not found in map", async () => {
+    const entity = makeEntity({
+      refs: { issue: { adapter: "missing", id: "1" } },
+    });
+    const state = makeState({ promptTemplate: "ok" });
+    const result = await buildInvocation(entity, state, new Map());
+    expect(result.context.refs).toEqual({});
+  });
+
+  it("skips ref when adapter.get throws", async () => {
+    const entity = makeEntity({
+      refs: { issue: { adapter: "broken", id: "1" } },
+    });
+    const adapters = new Map<string, { get: (id: string) => Promise<unknown> }>([
+      ["broken", { get: async () => { throw new Error("fail"); } }],
+    ]);
+    const state = makeState({ promptTemplate: "ok" });
+    const result = await buildInvocation(entity, state, new Map(adapters));
+    expect(result.context.refs).toEqual({});
+  });
+
+  it("includes pipeline metadata in context", async () => {
+    const entity = makeEntity({ artifacts: { spec: "data" } });
+    const state = makeState({ agentRole: "coder" });
+    const invocations = [
+      { stage: "review" },
+      { stage: "review" },
+      { stage: "build" },
+    ];
+    const result = await buildInvocation(entity, state, new Map(), invocations);
+    expect(result.context.agent_role).toBe("coder");
+    expect(result.context.invocation_count).toBe(2); // "review" stage matches state.name
+    expect(result.context.total_invocations).toBe(3);
+    expect(typeof result.context.time_in_state).toBe("number");
+    expect(result.context.time_in_state).toBeGreaterThanOrEqual(9000);
+  });
+
+  it("defaults invocations to empty array", async () => {
+    const entity = makeEntity();
+    const state = makeState();
+    const result = await buildInvocation(entity, state, new Map());
+    expect(result.context.invocation_count).toBe(0);
+    expect(result.context.total_invocations).toBe(0);
+  });
+
+  it("includes entity in context for Handlebars helpers", async () => {
+    const entity = makeEntity({
+      artifacts: { diff: "x" },
+    });
+    const state = makeState({
+      promptTemplate: '{{#if (has_artifact entity "diff")}}HAS_DIFF{{/if}}',
+    });
+    const result = await buildInvocation(entity, state, new Map());
+    expect(result.prompt).toBe("HAS_DIFF");
+  });
+});
+
+describe("hydrateGateCommand", () => {
+  it("hydrates a gate command template with context", () => {
+    const gate: Gate = {
+      id: "g1",
+      name: "lint",
+      type: "command",
+      command: "cd {{workdir}} && pnpm lint",
+      functionRef: null,
+      apiConfig: null,
+      timeoutMs: 30000,
+    };
+    const result = hydrateGateCommand(gate, { workdir: "/tmp/repo" });
+    expect(result).toBe("cd /tmp/repo && pnpm lint");
+  });
+
+  it("returns empty string when gate.command is null", () => {
+    const gate: Gate = {
+      id: "g1",
+      name: "fn-gate",
+      type: "function",
+      command: null,
+      functionRef: "checkLint",
+      apiConfig: null,
+      timeoutMs: 30000,
+    };
+    expect(hydrateGateCommand(gate, {})).toBe("");
+  });
+
+  it("leaves template vars unresolved when not in context", () => {
+    const gate: Gate = {
+      id: "g1",
+      name: "test",
+      type: "command",
+      command: "run {{missing}}",
+      functionRef: null,
+      apiConfig: null,
+      timeoutMs: 30000,
+    };
+    expect(hydrateGateCommand(gate, {})).toBe("run ");
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1815

- Extracts shared Handlebars instance into `src/engine/handlebars.ts` with `getHandlebars()` and `registerHelper()` exports
- Refactors `state-machine.ts` to import from the shared module instead of creating its own instance
- Implements `src/engine/invocation-builder.ts` with `buildInvocation()` (ref resolution via adapters, artifact assembly, template hydration) and `hydrateGateCommand()`
- Adds barrel exports in `src/engine/index.ts`
- 22 new tests covering all edge cases (null refs, missing adapters, adapter errors, null templates, pipeline metadata)

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run tests/engine/handlebars.test.ts tests/engine/invocation-builder.test.ts tests/engine/state-machine.test.ts` — 48 tests pass
- [x] `npm run check` (biome + tsc) passes

Generated with Claude Code

## Summary by Sourcery

Introduce a shared Handlebars engine and an invocation builder for hydrating prompts and gate commands with entity context, refs, and pipeline metadata.

New Features:
- Add an invocation builder that assembles context from entities, resolves external refs via adapters, and hydrates state prompt templates.
- Add a helper to hydrate gate command templates using shared Handlebars.
- Expose shared Handlebars accessors and invocation utilities from the engine module for external use.

Enhancements:
- Centralize Handlebars setup and helper registration in a shared engine module and update the state machine to consume it.

Tests:
- Add comprehensive tests for the shared Handlebars helpers and the invocation builder covering refs, artifacts, null templates, adapter failures, and pipeline metadata.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared Handlebars instance with built-in helpers and wire `engine.invocation-builder.buildInvocation` to hydrate prompt templates and gate commands for invocation builder (WOP-1815)
> Introduce a shared Handlebars instance with built-in helpers and expose `getHandlebars`/`registerHelper`; add `engine.invocation-builder.buildInvocation` to compile state `promptTemplate` with refs, artifacts, and invocation metadata; add `engine.invocation-builder.hydrateGateCommand`; update exports and switch state machine to the shared instance.
>
> #### 🖇️ Linked Issues
> This pull request implements work for [WOP-1815](https://linear.app/wopr/issue/WOP-1815) by adding Handlebars hydration and reference resolution to the invocation builder.
>
> #### 📍Where to Start
> Start with `buildInvocation` in [invocation-builder.ts](https://github.com/wopr-network/defcon/pull/13/files#diff-62f0d7af743ea67ab5d33b9e511da78e1975a1cdac4769296659d9ee4ad34c6a), then review the shared Handlebars setup in [handlebars.ts](https://github.com/wopr-network/defcon/pull/13/files#diff-bbe323e242506cd2ebc3fe55c01aff2322ce6798cf32458096eea2f007aba3b1) and how it is consumed in [state-machine.ts](https://github.com/wopr-network/defcon/pull/13/files#diff-3b72228d0cc7a9ca02e689fe900f8b8f186cc32c2a876df35d07e1429dd7b297).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 308dfab. 4 files reviewed, 4 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/engine/invocation-builder.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 47](https://github.com/wopr-network/defcon/blob/308dfab36afc5d788ef860c4c2655e640e8d2c03/src/engine/invocation-builder.ts#L47): The `time_in_state` calculation relies on `entity.updatedAt`, which typically updates on any modification to the entity record (e.g., when `claimedAt` or `artifacts` changes), not just when the state transitions. This causes the `time_in_state` metric to reset to zero incorrectly during the lifecycle of a state, effectively breaking any prompts or gates that rely on this value for timeout/SLA logic (e.g., "escalate if > 2 hours"). A stable timestamp representing when the state was entered (e.g., `stateEnteredAt`) should be used instead. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->