### PR TITLE
ci: use self-hosted Linux X64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Switches CI from `ubuntu-latest` (GitHub-hosted) to `[self-hosted, Linux, X64]` to match the rest of the WOPR network repos.

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

CI:
- Update GitHub Actions workflow to use a self-hosted Linux X64 runner for the main CI job.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch CI job runner in `[ci.yml](https://github.com/wopr-network/defcon/pull/15/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f)` to `[self-hosted, Linux, X64]` to use a self-hosted Linux X64 runner
> Update the `ci` job in `[ci.yml](https://github.com/wopr-network/defcon/pull/15/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f)` to run on the `[self-hosted, Linux, X64]` label instead of `ubuntu-latest`.
>
> #### 📍Where to Start
> Start with the `ci` job definition in `[ci.yml](https://github.com/wopr-network/defcon/pull/15/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f)`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34b7d6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->