### PR TITLE
feat: WOPR changeset flow seed — replaces /wopr:auto (WOP-1829)

### DIFF
--- a/gates/blocking-graph.ts
+++ b/gates/blocking-graph.ts
@@ -12,9 +12,12 @@
  * runtime, not compiled by the main build.
  */
 
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { LinearClient } from "@linear/sdk";
-import { execFileSync } from "node:child_process";
 import type { Entity } from "../src/repositories/interfaces.js";
+
+const execFileAsync = promisify(execFile);
 
 export interface BlockingGraphResult {
   passed: boolean;
@@ -59,39 +62,51 @@ export async function isUnblocked(entity: Entity): Promise<BlockingGraphResult> 
   const unmerged: string[] = [];
 
   for (const relation of blockers) {
-    const relatedIssue = await relation.relatedIssue;
-    if (!relatedIssue) continue;
-
-    const identifier = relatedIssue.identifier;
-
-    // Resolve the PR via Linear attachment — the attachment URL tells us which repo
-    const attachments = await relatedIssue.attachments();
-    const prAttachment = attachments.nodes.find(
-      (a) => a.url?.includes("github.com") && a.url?.includes("/pull/"),
-    );
-    if (!prAttachment?.url) {
-      unmerged.push(`${identifier} (no PR found)`);
-      continue;
-    }
-    const match = prAttachment.url.match(
-      /github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/,
-    );
-    if (!match) {
-      unmerged.push(`${identifier} (unrecognized PR URL)`);
-      continue;
-    }
-    const [, repo, prNum] = match;
     try {
-      const state = execFileSync(
-        "gh",
-        ["pr", "view", prNum, "--repo", repo, "--json", "state", "--jq", ".state"],
-        { encoding: "utf-8", timeout: 10000 },
-      ).trim();
-      if (state !== "MERGED") {
-        unmerged.push(identifier);
+      const blockerIssue = await relation.issue;
+      if (!blockerIssue) continue;
+
+      const identifier = blockerIssue.identifier;
+
+      // Resolve the PR via Linear attachment — the attachment URL tells us which repo
+      const attachments = await blockerIssue.attachments();
+      const prAttachment = attachments.nodes.find((a) => {
+        if (!a.url) return false;
+        let hostname: string;
+        try {
+          hostname = new URL(a.url).hostname;
+        } catch {
+          return false;
+        }
+        return hostname === "github.com" && a.url.includes("/pull/");
+      });
+      if (!prAttachment?.url) {
+        unmerged.push(`${identifier} (no PR found)`);
+        continue;
       }
-    } catch {
-      unmerged.push(`${identifier} (gh check failed)`);
+      const match = prAttachment.url.match(
+        /github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/,
+      );
+      if (!match) {
+        unmerged.push(`${identifier} (unrecognized PR URL)`);
+        continue;
+      }
+      const [, repo, prNum] = match;
+      try {
+        const { stdout } = await execFileAsync(
+          "gh",
+          ["pr", "view", prNum, "--repo", repo, "--json", "state", "--jq", ".state"],
+          { timeout: 10000 },
+        );
+        if (stdout.trim() !== "MERGED") {
+          unmerged.push(identifier);
+        }
+      } catch {
+        unmerged.push(`${identifier} (gh check failed)`);
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      unmerged.push(`(blocker check failed: ${errMsg})`);
     }
   }
 

--- a/seeds/wopr-changeset.json
+++ b/seeds/wopr-changeset.json
@@ -37,7 +37,7 @@
       "agentRole": "wopr-reviewer",
       "modelTier": "sonnet",
       "mode": "active",
-      "promptTemplate": "Your name is \"reviewer-{{entity.refs.linear.id}}\". You are on the {{flow.name}} team.\n\n## Assignment\nPR: {{entity.artifacts.prUrl}} (#{{entity.artifacts.prNumber}})\nIssue: {{entity.refs.linear.key}}\nRepo: {{entity.refs.github.repo}}\n\n## Step 1: Wait for review bots\n```bash\n~/wopr-await-reviews.sh {{entity.artifacts.prNumber}} {{entity.refs.github.repo}}\n```\n\n## Step 2: Check CI status\n```bash\ngh pr checks {{entity.artifacts.prNumber}} --repo {{entity.refs.github.repo}}\n```\nIf ANY check is FAILING, report ISSUES immediately — no code review needed.\n\n## Step 3: Read ALL review comments\n```bash\n# Inline comments (WHERE QODO /improve SUGGESTIONS APPEAR)\ngh api repos/{{entity.refs.github.repo}}/pulls/{{entity.artifacts.prNumber}}/comments \\\n  --jq '.[] | \"[\\(.user.login)] \\(.path):\\(.line // \"?\") — \\(.body)\"'\n\n# Formal reviews\ngh pr view {{entity.artifacts.prNumber}} --repo {{entity.refs.github.repo}} --json reviews \\\n  --jq '.reviews[]? | \"[\\(.author.login) / \\(.state)] \\(.body)\"'\n\n# Top-level comments\ngh api repos/{{entity.refs.github.repo}}/issues/{{entity.artifacts.prNumber}}/comments \\\n  --jq '.[] | \"[\\(.user.login)] \\(.body)\"'\n```\n\nIMPORTANT: ALWAYS call `gh api repos/.../pulls/N/comments` for inline comments.\nIf a Qodo comment has `line: null`, it is outdated — reply to resolve it, do NOT treat as blocking.\nNEVER declare CLEAN if Qodo has any open /improve suggestions on current code.\n\n## Step 4: Read the diff\n```bash\ngh pr diff {{entity.artifacts.prNumber}} --repo {{entity.refs.github.repo}}\n```\n\n## Step 5: Render verdict\n- If all CI green AND no actionable findings: \"CLEAN: {{entity.artifacts.prUrl}}\"\n- If issues found: \"ISSUES: {{entity.artifacts.prUrl}} — <finding1>; <finding2>\""
+      "promptTemplate": "Your name is \"reviewer-{{entity.refs.linear.id}}\". You are on the {{flow.name}} team.\n\n## Assignment\nPR: {{entity.artifacts.prUrl}} (#{{entity.artifacts.prNumber}})\nIssue: {{entity.refs.linear.key}}\nRepo: {{entity.refs.github.repo}}\n\n## Step 1: Wait for review bots\n```bash\n~/wopr-await-reviews.sh {{entity.artifacts.prNumber}} {{entity.refs.github.repo}}\n```\n\n## Step 2: Check CI status\n```bash\ngh pr checks {{entity.artifacts.prNumber}} --repo {{entity.refs.github.repo}}\n```\nIf ANY check is FAILING, report ISSUES immediately — no code review needed.\n\n## Step 3: Read ALL review comments\n```bash\n# Inline comments (WHERE QODO /improve SUGGESTIONS APPEAR)\ngh api repos/{{entity.refs.github.repo}}/pulls/{{entity.artifacts.prNumber}}/comments \\\n  --jq '.[] | \"[\\(.user.login)] \\(.path):\\(.line // \"?\") — \\(.body)\"'\n\n# Formal reviews\ngh pr view {{entity.artifacts.prNumber}} --repo {{entity.refs.github.repo}} --json reviews \\\n  --jq '.reviews[]? | \"[\\(.author.login) / \\(.state)] \\(.body)\"'\n\n# Top-level comments\ngh api repos/{{entity.refs.github.repo}}/issues/{{entity.artifacts.prNumber}}/comments \\\n  --jq '.[] | \"[\\(.user.login)] \\(.body)\"'\n```\n\nIMPORTANT: ALWAYS call `gh api repos/.../pulls/N/comments` for inline comments.\nIf a Qodo comment has `line: null`, it is outdated — reply to resolve it, do NOT treat as blocking.\nNEVER declare CLEAN if Qodo has any open /improve suggestions on current code.\n\n## Step 4: Read the diff\n```bash\ngh pr diff {{entity.artifacts.prNumber}} --repo {{entity.refs.github.repo}}\n```\n\n## Step 5: Render verdict\n- If all CI green AND no actionable findings: \"CLEAN: {{entity.artifacts.prUrl}}\"\n- If issues found: \"ISSUES: {{entity.artifacts.prUrl}} — <finding1>; <finding2>\"\n\n## Signal Format\nEnd your message to team-lead with exactly one of:\n- \"CLEAN: <pr-url>\" — if all checks pass and no findings\n- \"ISSUES: <pr-url> — <finding1>; <finding2>\" — if any issues found"
     },
     {
       "name": "fixing",
@@ -105,13 +105,6 @@
       "toState": "fixing",
       "trigger": "issues",
       "priority": 1
-    },
-    {
-      "flowName": "wopr-changeset",
-      "fromState": "reviewing",
-      "toState": "stuck",
-      "trigger": "escalate",
-      "priority": 2
     },
     {
       "flowName": "wopr-changeset",


### PR DESCRIPTION
## Summary
Adds `seeds/wopr-changeset.json` (declarative WOPR pipeline) and `gates/blocking-graph.ts` (blocker check gate). Closes WOP-1829.

- `seeds/wopr-changeset.json`: declarative 8-state pipeline (backlog → architecting → coding → reviewing → fixing → merging → stuck → done) with 2 gates, 11 transitions, 3 integrations
- `gates/blocking-graph.ts`: function gate that checks all Linear blockers have merged PRs before allowing transition from backlog

## Test plan
- [x] `node -e "JSON.parse(...)"` validates: 1 flow, 8 states, 2 gates, 11 transitions, 3 integrations
- [x] `pnpm build` passes

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Introduce a declarative WOPR changeset flow seed and a gate for enforcing blocker resolution before work starts.

New Features:
- Add a WOPR changeset seed defining an 8-state pipeline with gates, transitions, and external integrations.
- Add a custom blocking-graph gate that verifies all Linear blocker issues have corresponding merged GitHub PRs before allowing progression.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed the WOPR changeset flow and add `gates/blocking-graph.ts:isUnblocked` gate with a 10s `gh` check timeout to replace `/wopr:auto` (WOP-1829)
> Add `BlockingGraphResult` and `isUnblocked` in [gates/blocking-graph.ts](https://github.com/wopr-network/defcon/pull/24/files#diff-5cefd772c63621768bef57c42c6700cb7f31697f0107be54b7ee886e93fb1b6b) to validate Linear blockers via GitHub PR merge state, and introduce the `wopr-changeset` flow seed in [seeds/wopr-changeset.json](https://github.com/wopr-network/defcon/pull/24/files#diff-013d2fba1c541f82e531a0d8e8bcf3674f9067720ac58369f65af3420ccd4629).
>
> #### 🖇️ Linked Issues
> Resolves [WOP-1829](https://linear.app/wopr/issue/WOP-1829) by introducing the `wopr-changeset` seed to replace `/wopr:auto`.
>
> #### 📍Where to Start
> Start with the `isUnblocked` function in [gates/blocking-graph.ts](https://github.com/wopr-network/defcon/pull/24/files#diff-5cefd772c63621768bef57c42c6700cb7f31697f0107be54b7ee886e93fb1b6b), then review the `wopr-changeset` definitions in [seeds/wopr-changeset.json](https://github.com/wopr-network/defcon/pull/24/files#diff-013d2fba1c541f82e531a0d8e8bcf3674f9067720ac58369f65af3420ccd4629).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a92694.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gate to block progression when related blocking issues lack merged pull requests; reports which blockers remain.
  * Added a complete multi-stage changeset workflow (backlog → architecting → coding → reviewing → merging → done) with role-based agent prompts, gated merge readiness, escalation/stuck handling, and integrations for issue tracking, version control, and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->