### PR TITLE
docs: worker protocol, three-state gate semantics, failure/timeout prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,19 @@ These aren't suggestions in a prompt. They're shell commands the engine executes
 
 `claim` = *"I'm ready. What needs escalating?"*
 
-DEFCON hands the agent a prompt — the work for the current level. The agent doesn't know the flow. Doesn't know how many levels there are. Doesn't know what comes next. It just gets instructions and a signal to report when it's done.
+DEFCON hands the agent a prompt — the work for the current level. The agent doesn't know the flow. Doesn't know how many levels there are. Doesn't know what comes next. It just gets instructions and a signal to report when it's done. Pass a `workerId` so DEFCON knows who you are — if you don't have one yet, the first `claim` mints one for you and tells you to use it going forward.
 
 `report` = *"I did the thing. Am I clear to advance?"*
 
-DEFCON runs the gate. If it passes, the entity advances and the response contains the next prompt — the work for the next level. If it fails, the response says why and what to fix. If the entity reaches a terminal state, the response says "done."
+DEFCON runs the gate. The call blocks — the agent waits — until the gate resolves. That could be 200ms. It could be 8 minutes while CI finishes. The agent doesn't poll. It doesn't retry. It sits on the call. When the response comes back, there are exactly three outcomes:
+
+- **`continue`** — gate passed. The response contains the next prompt. Keep going.
+- **`waiting`** — gate failed. The response says why. The agent should stop — something external needs to change before the entity can advance. This is good news: DEFCON caught a real problem and is conserving the agent's context for work that matters.
+- **`check_back`** — gate timed out without resolving. This is not an error. The response says "call again after a short wait." The gate is still running; DEFCON just couldn't hold the connection long enough to see it finish.
 
 One `claim` to start. Then `report`, `report`, `report` until DEFCON says stop. The agent never decides what level comes next. It never decides "good enough." It does work, reports signals, and DEFCON — based on evidence, not opinion — tells it what to do.
+
+**Why `waiting` is the right response to a gate failure** — when a gate says no, there's nothing useful the agent can do. Keeping it spinning, re-reading the codebase, retrying the same check — that's wasted tokens. `waiting` is DEFCON telling the agent *stand down*. When something changes — a human intervenes, a dependency ships, a deploy completes — the entity gets reclaimed by a fresh agent with a full context window, not a stale one that's been burning tokens on hold.
 
 ### See It In Action
 
@@ -91,18 +97,20 @@ Agent: flow.claim()
 DEFCON: feat-392. State: "backlog". Write an implementation spec — read
         the codebase, identify the files, the function signatures, the
         edge cases. Post the spec on the issue. Report "spec_ready".
+        [workerId: wkr_abc123 — include this in all future flow calls]
 
         ... agent writes the spec ...
 
-Agent: flow.report({ signal: "spec_ready" })
+Agent: flow.report({ workerId: "wkr_abc123", signal: "spec_ready" })
 DEFCON: Gate passed. State: "coding". Implement the spec. Create a branch,
         write failing tests first, then implementation. Push a PR.
         Report "pr_created" with the PR URL.
 
         ... agent writes the code, pushes the PR ...
 
-Agent: flow.report({ signal: "pr_created", artifacts: { prUrl: "..." } })
-DEFCON: Running gate... tsc: PASS. biome: PASS. tests: PASS.
+Agent: flow.report({ workerId: "wkr_abc123", signal: "pr_created", artifacts: { prUrl: "..." } })
+DEFCON: Gate running... [8 minutes pass — CI is slow today]
+        tsc: PASS. biome: PASS. tests: PASS.
         State: "reviewing". Check CI on the PR. Read every review bot
         comment. Read the diff. Report one of two signals:
 
@@ -111,7 +119,7 @@ DEFCON: Running gate... tsc: PASS. biome: PASS. tests: PASS.
 
         ... agent reviews, security bot flagged unvalidated input ...
 
-Agent: flow.report({ signal: "issues", artifacts: { findings: "..." } })
+Agent: flow.report({ workerId: "wkr_abc123", signal: "issues", artifacts: { findings: "..." } })
 DEFCON: State: "fixing". Here's what the reviewer found:
         [unvalidated user input on line 47 of auth.ts]
         Fix it. Push. Report "fixes_pushed".
@@ -122,18 +130,27 @@ DEFCON: State: "fixing". Here's what the reviewer found:
 
         ... agent fixes the finding, pushes ...
 
-Agent: flow.report({ signal: "fixes_pushed" })
+Agent: flow.report({ workerId: "wkr_abc123", signal: "fixes_pushed" })
 DEFCON: State: "reviewing". Back to review. Not forward — back. A fresh
         check from scratch. Report "clean" or "issues".
 
         ... agent reviews again, everything clean this time ...
 
-Agent: flow.report({ signal: "clean" })
+Agent: flow.report({ workerId: "wkr_abc123", signal: "clean" })
+DEFCON: Gate running... [merge queue is backed up, gate timeout reached]
+        next_action: "check_back". Your report was received. The merge
+        queue gate is still evaluating — this is not an error. Call
+        flow.report again with the same arguments after a short wait.
+        retry_after_ms: 30000
+
+        ... agent waits 30 seconds, calls again ...
+
+Agent: flow.report({ workerId: "wkr_abc123", signal: "clean" })
 DEFCON: Gate passed. State: "merging". Merge queue entered.
 
         ... CI passes on merge commit ...
 
-Agent: flow.report({ signal: "merged" })
+Agent: flow.report({ workerId: "wkr_abc123", signal: "merged" })
 DEFCON: feat-392 is done.
 ```
 

--- a/docs/method/gates/gate-taxonomy.md
+++ b/docs/method/gates/gate-taxonomy.md
@@ -8,12 +8,24 @@ The categories of deterministic gates every agentic engineering project needs.
 
 A gate is a check that:
 
-1. **Has a binary outcome** — pass or fail, nothing in between
+1. **Has a ternary outcome** — pass, fail, or timeout (not yet resolved)
 2. **Is deterministic** — same input always produces the same result
 3. **Is automated** — no human judgment required
 4. **Blocks progress on failure** — work cannot advance past a failing gate
 
 Gates are not suggestions, warnings, or "consider this" comments. They are hard blocks.
+
+### The Three Outcomes
+
+| Outcome | Meaning | Worker action |
+|---|---|---|
+| **Pass** | Gate resolved affirmatively | Continue — receive next stage prompt |
+| **Fail** | Gate resolved negatively | Stop — entity is gated, wait for reclaim |
+| **Timeout** | Gate did not resolve within `timeout_ms` | Do timeout work, call report again |
+
+Timeout is not failure. A gate that hasn't resolved yet has not said no. The worker calls report again after a delay. The gate may pass on the next attempt.
+
+Each outcome has a different prompt source — see the [worker protocol](../pipeline/worker-protocol.md) for the full prompt resolution model.
 
 ---
 

--- a/docs/method/pipeline/worker-protocol.md
+++ b/docs/method/pipeline/worker-protocol.md
@@ -1,0 +1,143 @@
+# The Worker Protocol
+
+How agents participate in a gated pipeline — the claim/report contract, gate semantics, and why blocking is correct.
+
+---
+
+## The Two-Call Contract
+
+Every agent in a gated pipeline does the same thing regardless of what stage it's in:
+
+1. **Claim** — announce readiness, receive work
+2. **Report** — submit output, receive verdict
+
+That's the entire surface area. The agent never knows the flow definition. Never knows what state comes next. Never decides if its output is good enough. It does work and reports what happened. The pipeline decides what to do with that.
+
+This is not a limitation. It's the point. An agent that knows "if I say X, we skip the gate" is an agent that will eventually say X. An agent that can only report what it did — and then wait — cannot cheat the escalation.
+
+---
+
+## Workers
+
+Any process that can make two calls is a valid worker:
+
+- An autonomous agent loop polling for work
+- A Claude Code session where a human reviews each step
+- A shell script
+- A curl command
+
+The pipeline doesn't distinguish. A human-driven session that calls claim and report is architecturally identical to an autonomous agent doing the same. Both speak the same protocol. Both are subject to the same gates.
+
+This is the key property that separates this model from traditional worker queues: **workers can be humans**. A human saying "I'll take this one" is the same as an agent saying it. The claim is the claim.
+
+### Worker Identity
+
+Workers identify themselves with a `workerId`. This enables:
+
+- Idle detection (has this worker gone silent?)
+- Claim attribution (who holds this work?)
+- Dead worker reaping (release claims when a worker disappears)
+
+The `workerId` is obtained on first claim — if none is provided, one is minted and returned. The worker must carry it forward on every subsequent call. Each call resets the idle timer. **The calls are the heartbeat.** No separate keepalive mechanism is needed.
+
+Idle timeout is configured per worker at registration time, not globally. A human reviewer might need 30 minutes between calls. An automated agent loop might need 60 seconds. Same reaping logic, different patience.
+
+---
+
+## Gate Semantics
+
+A gate is a check that runs at a pipeline boundary. It has exactly three outcomes — and each one has a different prompt source:
+
+| Outcome | `next_action` | Prompt source |
+|---|---|---|
+| Gate passed | `continue` | Next state's `promptTemplate` — derived from the flow |
+| Gate failed | `waiting` | Gate's `failure_prompt` — written by the flow author |
+| Gate timed out | `check_back` | Gate's `timeout_prompt` — written by the flow author |
+
+The pass case requires no configuration. The next state already has a prompt template. The pipeline renders it and returns it. The flow author has nothing to add — the flow itself defines what work comes next.
+
+The fail and timeout cases are different. The engine knows the gate failed or timed out, but it doesn't know what that means in the context of this specific pipeline. That's what `failure_prompt` and `timeout_prompt` are for: the flow author's instructions to the worker about what just happened and what to do next.
+
+### 1. Pass — `continue`
+
+The gate resolved affirmatively. The entity advances. The worker receives the next stage's prompt — rendered from the next state's `promptTemplate` — and should keep going.
+
+### 2. Fail — `waiting`
+
+The gate resolved negatively. The entity stays where it is. The worker should **stop**.
+
+The response includes a `message` rendered from the gate's `failure_prompt`. A well-written failure prompt tells the worker exactly what failed, what it means, and — critically — that it should stop and not retry. Without a failure prompt, the worker receives a raw gate output dump and has to infer what to do. With one, the flow author controls the narrative.
+
+`waiting` is not a failure of the worker. It means the gate found a real problem — something that needs to change before this entity can advance. The right response is to do nothing. The entity will be reclaimed by a fresh worker when something external changes (a human intervenes, a dependency ships, a blocking issue is resolved).
+
+**Why stopping is correct:** A worker that keeps running after a gate failure burns context on work that cannot be used. A fresh worker, with a full context window, will do better work when the time comes. `waiting` is the pipeline conserving resources for when they're actually needed.
+
+### 3. Timeout — `check_back`
+
+The gate did not resolve within its configured window. **This is not an error.** The gate is still running. The worker's report was received.
+
+The response includes a `message` rendered from the gate's `timeout_prompt`. A well-written timeout prompt gives the worker real work to do while it waits — not busywork, but something useful like reviewing a diff or checking related issues. Without a timeout prompt, the worker gets a generic "try again" message.
+
+The worker calls report again with the same arguments after the suggested delay. The gate will either have resolved by then, or the worker will receive another `check_back`.
+
+---
+
+## The Blocking Call
+
+The report call blocks until the gate resolves. This is intentional.
+
+The worker waits on the call. It does not poll. It does not retry. It sits there until the gate finishes — whether that takes 200 milliseconds or 8 minutes. When the response arrives, it contains a definitive answer.
+
+The gate's `timeout_ms` is the maximum wait ceiling, not an expected duration. A gate configured for 10 minutes that resolves in 8 returns success at the 8-minute mark. A gate that hasn't resolved at 10 minutes returns `check_back`. Either way, the call returns when there's something to say.
+
+```
+Gate resolves in 8 min, timeout is 10 min  →  returns continue at 8 min
+Gate resolves in 12 min, timeout is 10 min →  returns check_back at 10 min
+Gate resolves in 200ms, timeout is 10 min  →  returns continue at 200ms
+```
+
+Set `timeout_ms` to the maximum time you are willing to wait, not an estimate of how long the gate usually takes.
+
+---
+
+## Token Economics
+
+Gates save tokens by preventing wasted work.
+
+When a gate fails, the worker stops. This is good. The alternative — continuing to run, re-reading the codebase, trying variations, re-attempting the blocked step — burns tokens on work that cannot advance the entity. None of that output can be used. It's waste.
+
+When a gate passes, the pipeline hands the worker the next prompt with full context already loaded. The worker's context window is spent on productive work from the first token.
+
+When a gate times out, the `check_back` response can include a `timeout_prompt` — instructions for what the worker should do while waiting. A well-designed timeout prompt turns idle time into useful work: pre-reviewing a diff, writing notes, checking related issues. The worker is never just burning tokens on hold.
+
+The protocol is designed around the insight that **a stopped worker costs nothing, and a fresh worker does better work than an exhausted one**.
+
+---
+
+## Configuring Timeouts
+
+Timeouts are configurable at two levels:
+
+**Gate level** — how long this specific gate waits before returning `check_back`. Use for gates with known duration characteristics (a security scanner that always takes 20 minutes).
+
+**Flow level** — the default for all gates in the flow. Use to tune the pipeline for its environment (a fast CI environment vs a slow one).
+
+Gate-level overrides flow-level. Flow-level overrides the system default.
+
+### Timeout Prompts
+
+Gates and flows can define a `timeout_prompt` — what the worker should do during a `check_back`. This is a prompt template with access to the same context as the stage prompt.
+
+A good timeout prompt gives the worker real work, not busywork. "While CI runs, review the diff and note any concerns you'd raise regardless of CI outcome" is useful. "Wait and try again" is not.
+
+---
+
+## Why This Model Works
+
+Traditional pipeline models push work to workers — the scheduler assigns tasks, workers execute, results come back. The worker is passive.
+
+This model inverts that. Workers pull work via claim. Gates pull verdicts via report. Nothing is pushed. The worker is always in control of when it's ready to receive work and when it has something to report.
+
+That inversion makes workers composable. A human, an agent, a script — all can participate in the same pipeline because they all speak the same two-call protocol. The pipeline doesn't care what's on the other end of the call. It cares that the call is made.
+
+See [WOPR implementation](../../wopr/pipeline/worker-protocol.md) for concrete schema and configuration.

--- a/docs/wopr/pipeline/worker-protocol.md
+++ b/docs/wopr/pipeline/worker-protocol.md
@@ -1,0 +1,229 @@
+# Worker Protocol — DEFCON Implementation
+
+The concrete implementation of the [worker protocol](../../method/pipeline/worker-protocol.md) in DEFCON.
+
+---
+
+## The Two MCP Tools
+
+DEFCON exposes the worker protocol as two MCP tools:
+
+### `flow.claim`
+
+```json
+{
+  "workerId": "wkr_abc123",
+  "agentRole": "reviewer"
+}
+```
+
+Both fields are optional. If `workerId` is omitted, DEFCON auto-registers a new worker and returns the ID in the response — the worker must carry it forward on every subsequent call.
+
+`agentRole` filters claims to invocations matching that role. Omit to claim any available work.
+
+**Response (work available):**
+```json
+{
+  "entityId": "feat-392",
+  "invocationId": "inv_xyz",
+  "stage": "reviewing",
+  "prompt": "Check CI on the PR at https://github.com/...",
+  "workerId": "wkr_abc123"
+}
+```
+
+**Response (no work available):**
+```json
+{
+  "workerId": "wkr_abc123",
+  "invocation": null
+}
+```
+
+**Response (first call, no workerId provided):**
+```json
+{
+  "entityId": "feat-392",
+  "invocationId": "inv_xyz",
+  "stage": "reviewing",
+  "prompt": "...",
+  "workerId": "wkr_abc123",
+  "worker_notice": "No workerId provided. A worker has been registered for you. YOU MUST pass workerId: \"wkr_abc123\" in all future flow.claim and flow.report calls. Omitting it will generate a new worker each time."
+}
+```
+
+---
+
+### `flow.report`
+
+```json
+{
+  "workerId": "wkr_abc123",
+  "entityId": "feat-392",
+  "signal": "clean",
+  "artifacts": {
+    "prUrl": "https://github.com/...",
+    "reviewSummary": "All checks pass."
+  }
+}
+```
+
+**This call blocks until the gate resolves.** Do not set a short timeout on the MCP client. The call will return when it has something definitive to say — which may take milliseconds or many minutes.
+
+**Response — gate passed (`continue`):**
+```json
+{
+  "next_action": "continue",
+  "new_state": "merging",
+  "prompt": "Enter merge queue. Report 'merged' when done."
+}
+```
+
+**Response — gate failed (`waiting`):**
+```json
+{
+  "next_action": "waiting",
+  "gated": true,
+  "gateName": "ci-gate",
+  "gate_output": "Tests failed: 3 assertions in auth.test.ts",
+  "message": "CI failed on https://github.com/... The gate output was:\n\nTests failed: 3 assertions in auth.test.ts\n\nThis entity is now gated. Do not retry — wait to be reclaimed when the failures are addressed."
+}
+```
+
+Stop. Do not retry. Wait for reclaim. The `message` is rendered from the gate's `failure_prompt`. If no `failure_prompt` is configured, `message` is omitted and only `gate_output` is returned.
+
+**Response — gate timed out (`check_back`):**
+```json
+{
+  "next_action": "check_back",
+  "message": "Your report was received. The gate is still evaluating — this is not an error. Call flow.report again with the same arguments after a short wait.",
+  "retry_after_ms": 30000
+}
+```
+
+Call `flow.report` again with the same `entityId`, `signal`, and `artifacts` after `retry_after_ms`. No state is lost.
+
+---
+
+## Worker Identity and Idle Reaping
+
+Every `flow.claim` and `flow.report` call resets the worker's idle timer. These calls are the heartbeat. No separate keepalive is needed.
+
+If a worker goes idle (no claim or report for longer than its `idle_timeout_ms`), DEFCON releases its held claims so other workers can pick them up.
+
+`idle_timeout_ms` is configured per worker:
+- Automated agent loops: default 60s
+- Human/Claude Code sessions: default 1800s (30 min)
+
+Workers created via `defcon worker new` (CLI) or auto-registered on first claim use the appropriate default based on context.
+
+---
+
+## Gate Configuration
+
+Gates are defined in the flow seed file. All three prompt types are configurable at gate and flow level:
+
+```json
+{
+  "id": "my-pipeline",
+  "gate_timeout_ms": 600000,
+  "failure_prompt": "A gate failed. The entity is now gated — do not retry. Wait to be reclaimed.",
+  "timeout_prompt": "The gate is still evaluating. Review any open questions on this entity and add notes. Then call flow.report again with the same arguments.",
+  "states": [
+    {
+      "name": "reviewing",
+      "transitions": [
+        {
+          "on": "clean",
+          "to": "merging",
+          "gates": [
+            {
+              "name": "merge-queue-gate",
+              "type": "shell",
+              "command": "gh pr checks {{entity.artifacts.prNumber}} --repo {{entity.refs.github.repo}} --watch",
+              "timeout_ms": 1200000,
+              "failure_prompt": "The merge queue failed for {{entity.artifacts.prUrl}}. Output:\n\n{{gate.output}}\n\nThe entity is gated — check if CI failed on the merge commit or if there are conflicts. Do not retry.",
+              "timeout_prompt": "The merge queue is still running for {{entity.artifacts.prUrl}}. No action needed — call flow.report again with the same signal after the retry delay."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Timeout resolution order
+
+1. Gate `timeout_ms` — if set on the gate
+2. Flow `gate_timeout_ms` — if set on the flow
+3. `DEFCON_DEFAULT_GATE_TIMEOUT_MS` env var
+4. System default: 300000ms (5 minutes)
+
+### Prompt resolution order (same for all three prompt types)
+
+| Prompt type | Gate field | Flow field | System default |
+|---|---|---|---|
+| Pass | — | — | Next state's `promptTemplate` (always) |
+| Fail | `failure_prompt` | `failure_prompt` | Raw `gate_output` only, no `message` |
+| Timeout | `timeout_prompt` | `timeout_prompt` | "Not an error, call again" |
+
+All prompt templates are Handlebars and share the same context: `entity` (fields + refs + artifacts), `gate` (name, output), `flow` (name, config).
+
+---
+
+## Three Outcomes — Decision Table
+
+| Gate result | `next_action` | Prompt source | Worker should |
+|---|---|---|---|
+| Resolved true | `continue` | Next state's `promptTemplate` | Keep going |
+| Resolved false | `waiting` | Gate/flow `failure_prompt` | Stop — do not retry |
+| Timed out | `check_back` | Gate/flow `timeout_prompt` | Do timeout work, call report again |
+
+**Pass** — the flow decides what comes next. The worker receives the next state's rendered prompt and continues.
+
+**Fail** — the flow author decides what the worker should know. A good `failure_prompt` names the gate, quotes the output, and explicitly says "do not retry." Without it, the worker gets raw output and has to infer.
+
+**Timeout** — the flow author decides what the worker should do while waiting. A good `timeout_prompt` gives the worker real work, not just "try again." Without it, the worker gets a generic message.
+
+`waiting` is not a failure of the worker. It means a real problem was found. A fresh worker with a full context window will handle it when something changes. Stopping is the correct response — running burns context on work that cannot advance the entity.
+
+`check_back` is not an error. The gate is still running. The report was received. Call again after `retry_after_ms`.
+
+---
+
+## Why `flow.report` Blocks
+
+The blocking behavior is deliberate and load-bearing.
+
+When `flow.report` blocks, the worker's context window is occupied by the current task. It cannot be reassigned. It cannot drift. It is waiting for a definitive answer before deciding what to do next.
+
+When `flow.report` returns, the answer is final. Pass, fail, or check-back — there is no ambiguous state. The worker acts on it immediately.
+
+If `flow.report` were non-blocking — if it returned "submitted, check back later" — the worker would need to manage its own retry state, decide how often to poll, and handle the case where it's been reassigned in the meantime. All of that complexity is eliminated by blocking. The call is simple because the semantics are simple: wait until there's an answer, then act on it.
+
+The MCP client must not apply a short HTTP timeout to `flow.report`. The stdio transport has no timeout by default. For HTTP/SSE transports, configure an explicit long timeout (24h is safe) on this tool specifically.
+
+---
+
+## Spawning a Claude Code Session as a Worker
+
+```bash
+defcon worker new --role reviewer --idle-timeout 1800
+```
+
+This registers a new worker and opens a Claude Code session with a rendered prompt:
+
+```
+You are DEFCON worker wkr_abc123. Role: reviewer.
+Connected to DEFCON at <mcpUrl> via MCP.
+
+Use flow.claim to pick up available work, perform the task, then use
+flow.report to submit your result. Pass your workerId in every call.
+
+Keep claiming until no work is available or you are told to stop.
+```
+
+The human drives the session. DEFCON sees a registered worker. The claim/report protocol is identical to any other worker. The pipeline does not know or care that there's a human making the decisions.
+
+This is the mechanism for human-in-the-loop stages: define a stage with `agentRole: "human-reviewer"`, assign workers with that role to human sessions, and those stages will only be claimed by humans. The gate still runs. The escalation still holds. The human is just the one doing the work.


### PR DESCRIPTION
## Summary

Captures institutional knowledge about how DEFCON's worker protocol and gate semantics actually work — the design intent that isn't fully expressed in code.

### What changed

- **README** — three `flow.report` outcomes (`continue`/`waiting`/`check_back`), `workerId` flow through the exchange example, why `waiting` saves tokens, `check_back` example showing merge queue timeout scenario
- **`docs/method/pipeline/worker-protocol.md`** (new) — tool-agnostic worker protocol: worker identity, gate ternary semantics, blocking call rationale, token economics, timeout/prompt configuration model
- **`docs/wopr/pipeline/worker-protocol.md`** (new) — DEFCON implementation: full MCP tool schemas, response shapes for all three outcomes, prompt resolution order table, `failure_prompt`/`timeout_prompt` examples with real gate config
- **`docs/method/gates/gate-taxonomy.md`** — corrected "binary outcome" → "ternary outcome", added three-outcome table, cross-reference to worker protocol

### Key design decisions captured

1. **Three gate outcomes, not two** — pass (`continue`), fail (`waiting`), timeout (`check_back`). Timeout ≠ failure.
2. **Prompt source asymmetry** — pass prompt comes from the flow (next state's `promptTemplate`); fail and timeout prompts come from the gate/flow author (`failure_prompt`, `timeout_prompt`). Pass needs no config because the flow already defines what comes next.
3. **`flow.report` blocks** — the call holds open until the gate resolves. Set `timeout_ms` as a ceiling, not an estimate.
4. **`waiting` is good** — stops the worker, conserves context, fresh worker picks up when conditions change.
5. **`workerId` via auto-registration** — first `flow.claim` with no ID mints one and tells the worker to use it going forward. Calls are the heartbeat.

### Related Linear stories
- WOP-1884 — three-state gate outcomes
- WOP-1885 — configurable gate timeout
- WOP-1886 — configurable `timeout_prompt`
- WOP-1887 — `failure_prompt` on gates
- WOP-1882 — auto-register worker on first claim
- WOP-1883 — `flow.report` blocking semantics
- WOP-1881 — `defcon worker new`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document DEFCON’s worker protocol and gate semantics, wire the MCP server to the shared engine for flow.report handling, and rename the CLI/bin from agentic to defcon.

New Features:
- Expose explicit next_action semantics and gate-passed names from flow.report so workers can distinguish continue, waiting, completed, and gated states.

Enhancements:
- Refactor flow.report handling in the MCP server to delegate transition and gate evaluation to the shared engine while returning richer next_action, prompt, and gates_passed metadata.
- Extend the engine’s processSignal API to track triggering invocations, emit gate-passed events with gate names, and record accurate transition logs.
- Adjust the active runner to pass invocation IDs through to the engine when processing signals.
- Wire the CLI ‘serve’ path to construct and reuse a shared Engine instance with an appropriate event bus based on transport mode.

Build:
- Rename the CLI binary and program name from agentic to defcon in the CLI and package.json exports.

Documentation:
- Rewrite the README to introduce DEFCON, its gated pipeline model, and updated documentation layout.
- Add a method-level worker protocol spec describing the claim/report contract, ternary gate outcomes, blocking semantics, and timeout configuration.
- Add a WOPR implementation guide for the worker protocol covering MCP tool schemas, response shapes, worker identity, and gate prompt resolution.
- Update the gate taxonomy docs to describe ternary gate outcomes and reference the worker protocol docs.

Tests:
- Update MCP server and active runner tests to reflect engine-driven flow.report behavior, gating semantics, and invocation lifecycle changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document worker protocol by requiring `workerId`, defining three-state gate outcomes, and detailing blocking `flow.report` semantics across README and worker-protocol docs
> Add `workerId` requirements, define gate outcomes (`continue`, `waiting`, `check_back`), and document blocking and timeout behavior for `flow.claim`/`flow.report` with DEFCON MCP examples in [README.md](https://github.com/wopr-network/defcon/pull/44/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [docs/method/gates/gate-taxonomy.md](https://github.com/wopr-network/defcon/pull/44/files#diff-3c92111cabf730759385e0fc7a063460d2f69983167340a5929c643c8ac92f10), [docs/method/pipeline/worker-protocol.md](https://github.com/wopr-network/defcon/pull/44/files#diff-29af746819f7799fd325e8e599e1eb5888a372e2731368d509ca8140b249acc5), and [docs/wopr/pipeline/worker-protocol.md](https://github.com/wopr-network/defcon/pull/44/files#diff-4eb9f69cf47ab204b3305eebe811449d02f412770d7ea0efcb795f3091ce0685).
>
> #### 📍Where to Start
> Start with the protocol overview in [docs/method/pipeline/worker-protocol.md](https://github.com/wopr-network/defcon/pull/44/files#diff-29af746819f7799fd325e8e599e1eb5888a372e2731368d509ca8140b249acc5), then review DEFCON specifics in [docs/wopr/pipeline/worker-protocol.md](https://github.com/wopr-network/defcon/pull/44/files#diff-4eb9f69cf47ab204b3305eebe811449d02f412770d7ea0efcb795f3091ce0685).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 575e7b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->