### PR TITLE
security: detect and reject circular spawnFlow chains (WOP-1849)

### DIFF
--- a/src/config/zod-schemas.ts
+++ b/src/config/zod-schemas.ts
@@ -247,6 +247,47 @@ export const SeedFileSchema = z
         });
       }
     }
+
+    // Detect circular spawnFlow chains via DFS
+    const spawnAdj = new Map<string, Set<string>>();
+    for (const t of seed.transitions) {
+      if (t.spawnFlow && flowNames.has(t.flowName) && flowNames.has(t.spawnFlow)) {
+        if (!spawnAdj.has(t.flowName)) spawnAdj.set(t.flowName, new Set());
+        spawnAdj.get(t.flowName)?.add(t.spawnFlow);
+      }
+    }
+
+    const visited = new Set<string>();
+    const inStack = new Set<string>();
+
+    function dfs(node: string, path: string[]): string[] | null {
+      if (inStack.has(node)) return [...path, node];
+      if (visited.has(node)) return null;
+      visited.add(node);
+      inStack.add(node);
+      for (const neighbor of spawnAdj.get(node) ?? []) {
+        const cycle = dfs(neighbor, [...path, node]);
+        if (cycle) return cycle;
+      }
+      inStack.delete(node);
+      return null;
+    }
+
+    for (const flowName of spawnAdj.keys()) {
+      if (visited.has(flowName)) continue;
+      const cycle = dfs(flowName, []);
+      if (cycle) {
+        const cycleStart = cycle[cycle.length - 1];
+        const cycleStartIdx = cycle.indexOf(cycleStart);
+        const cyclePath = cycle.slice(cycleStartIdx);
+        ctx.addIssue({
+          code: "custom",
+          message: `Circular spawnFlow chain detected: ${cyclePath.join(" -> ")}`,
+          path: ["transitions"],
+        });
+        break;
+      }
+    }
   });
 
 // ─── Inferred Types ───

--- a/tests/config/zod-schemas.test.ts
+++ b/tests/config/zod-schemas.test.ts
@@ -544,4 +544,102 @@ describe("SeedFileSchema", () => {
       expect(result.data.integrations).toEqual([]);
     }
   });
+
+  it("rejects direct self-spawn cycle (A spawns A)", () => {
+    const seed = {
+      flows: [{ name: "flow-a", initialState: "open" }],
+      states: [
+        { name: "open", flowName: "flow-a" },
+        { name: "done", flowName: "flow-a" },
+      ],
+      transitions: [
+        { flowName: "flow-a", fromState: "open", toState: "done", trigger: "finish", spawnFlow: "flow-a" },
+      ],
+    };
+    const result = SeedFileSchema.safeParse(seed);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.toLowerCase().includes("circular") && m.includes("flow-a"))).toBe(true);
+    }
+  });
+
+  it("rejects two-flow circular spawn chain (A spawns B, B spawns A)", () => {
+    const seed = {
+      flows: [
+        { name: "flow-a", initialState: "start" },
+        { name: "flow-b", initialState: "start" },
+      ],
+      states: [
+        { name: "start", flowName: "flow-a" },
+        { name: "end", flowName: "flow-a" },
+        { name: "start", flowName: "flow-b" },
+        { name: "end", flowName: "flow-b" },
+      ],
+      transitions: [
+        { flowName: "flow-a", fromState: "start", toState: "end", trigger: "go", spawnFlow: "flow-b" },
+        { flowName: "flow-b", fromState: "start", toState: "end", trigger: "go", spawnFlow: "flow-a" },
+      ],
+    };
+    const result = SeedFileSchema.safeParse(seed);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.toLowerCase().includes("circular"))).toBe(true);
+    }
+  });
+
+  it("rejects three-flow circular spawn chain (A→B→C→A)", () => {
+    const seed = {
+      flows: [
+        { name: "flow-a", initialState: "s" },
+        { name: "flow-b", initialState: "s" },
+        { name: "flow-c", initialState: "s" },
+      ],
+      states: [
+        { name: "s", flowName: "flow-a" },
+        { name: "e", flowName: "flow-a" },
+        { name: "s", flowName: "flow-b" },
+        { name: "e", flowName: "flow-b" },
+        { name: "s", flowName: "flow-c" },
+        { name: "e", flowName: "flow-c" },
+      ],
+      transitions: [
+        { flowName: "flow-a", fromState: "s", toState: "e", trigger: "go", spawnFlow: "flow-b" },
+        { flowName: "flow-b", fromState: "s", toState: "e", trigger: "go", spawnFlow: "flow-c" },
+        { flowName: "flow-c", fromState: "s", toState: "e", trigger: "go", spawnFlow: "flow-a" },
+      ],
+    };
+    const result = SeedFileSchema.safeParse(seed);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.toLowerCase().includes("circular"))).toBe(true);
+    }
+  });
+
+  it("accepts acyclic spawn chains (A spawns B, B spawns C, no cycle)", () => {
+    const seed = {
+      flows: [
+        { name: "flow-a", initialState: "s" },
+        { name: "flow-b", initialState: "s" },
+        { name: "flow-c", initialState: "s" },
+      ],
+      states: [
+        { name: "s", flowName: "flow-a" },
+        { name: "e", flowName: "flow-a" },
+        { name: "s", flowName: "flow-b" },
+        { name: "e", flowName: "flow-b" },
+        { name: "s", flowName: "flow-c" },
+        { name: "e", flowName: "flow-c" },
+      ],
+      transitions: [
+        { flowName: "flow-a", fromState: "s", toState: "e", trigger: "go", spawnFlow: "flow-b" },
+        { flowName: "flow-b", fromState: "s", toState: "e", trigger: "go", spawnFlow: "flow-c" },
+        { flowName: "flow-c", fromState: "s", toState: "e", trigger: "go" },
+      ],
+    };
+    const result = SeedFileSchema.safeParse(seed);
+    expect(result.success).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
Closes WOP-1849

- Added DFS cycle detection inside `SeedFileSchema.superRefine` to reject circular `spawnFlow` chains at seed-load time
- Builds an adjacency map from flow names to `spawnFlow` targets, then runs DFS looking for back-edges
- Emits a Zod issue with the cycle path when a cycle is detected
- Added 4 new test cases covering: self-spawn, 2-flow cycle, 3-flow cycle, and acyclic chain (allowed)

## Test plan
- [x] `pnpm run check` passes (biome + tsc)
- [x] `npx vitest run tests/config/zod-schemas.test.ts` — 42 tests pass

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Add validation to detect and reject circular spawnFlow chains in seed configuration files and cover the behavior with new schema tests.

New Features:
- Validate seed configurations for circular spawnFlow chains and surface a descriptive error when a cycle is detected.

Tests:
- Add schema tests covering self-spawn, two-flow and three-flow spawn cycles, and an allowed acyclic spawn chain.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect and reject circular `spawnFlow` chains in `SeedFileSchema.superRefine` for security in [zod-schemas.ts](https://github.com/wopr-network/defcon/pull/49/files#diff-908801e993f8282d98e5d7a2ad3a9f2fa94447474c098c2cefef52a0f042564e)
> Add DFS-based cycle detection over spawn adjacency to flag circular transitions and emit a custom issue on `['transitions']`; add tests covering self-cycle, two-flow, three-flow cycles, and an acyclic chain.
>
> #### 🖇️ Linked Issues
> Addresses [WOP-1849](ticket:jira/WOP-1849) by enforcing rejection of circular `spawnFlow` chains during seed file validation.
>
> #### 📍Where to Start
> Start in `SeedFileSchema.superRefine` within [zod-schemas.ts](https://github.com/wopr-network/defcon/pull/49/files#diff-908801e993f8282d98e5d7a2ad3a9f2fa94447474c098c2cefef52a0f042564e), focusing on the spawn adjacency construction and `dfs` cycle detection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05cf540.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced seed file validation to detect and report circular dependencies in spawn flows, preventing invalid configuration chains.

* **Tests**
  * Added comprehensive test coverage for circular spawn flow detection, including direct cycles, multi-flow chains, and acyclic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->