### PR TITLE
docs: discipline model, event ingestion, worker protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,21 @@ These aren't suggestions in a prompt. They're shell commands the engine executes
 
 `claim` = *"I'm ready. What needs escalating?"*
 
-DEFCON hands the agent a prompt — the work for the current level. The agent doesn't know the flow. Doesn't know how many levels there are. Doesn't know what comes next. It just gets instructions and a signal to report when it's done. Pass a `workerId` so DEFCON knows who you are — if you don't have one yet, the first `claim` mints one for you and tells you to use it going forward.
+Workers declare a **discipline** — not a task role. `claim(role: "engineering")` means: I am an engineering mind. Give me the highest-priority engineering work across all engineering flows. The pipeline picks the entity; the worker never does. An engineering worker IS the architect, coder, reviewer, fixer, and merger — these are states within one discipline, not separate agents. One `claim`, then sequential `report`s until the entity is done or gated.
+
+DEFCON hands the agent a prompt — the work for the current state. The agent doesn't know the flow. Doesn't know how many states there are. Doesn't know what comes next. It just gets instructions and a signal to report when it's done. Pass a `workerId` so DEFCON knows who you are — if you don't have one yet, the first `claim` mints one for you and tells you to use it going forward.
+
+When no work is available, `claim` returns a structured response — never bare null:
+
+```json
+{
+  "next_action": "check_back",
+  "retry_after_ms": 30000,
+  "message": "No work available. Call claim again after the retry delay."
+}
+```
+
+Same semantics as a gate timeout on `report`. The worker waits and retries.
 
 `report` = *"I did the thing. Am I clear to advance?"*
 
@@ -226,6 +240,10 @@ Every transition is earned. Every gate is deterministic. Every failure feeds bac
 ## Documentation
 
 **[`docs/method/`](docs/method/)** — The principles. Tool-agnostic patterns for building gated AI pipelines. Why deterministic gates work. How agents, triggers, and gates compose. Adopt it with whatever tools you use.
+
+Key method docs: [worker protocol](docs/method/pipeline/worker-protocol.md) · [disciplines](docs/method/pipeline/disciplines.md) · [gate taxonomy](docs/method/gates/gate-taxonomy.md) · [event ingestion](docs/method/pipeline/event-ingestion.md)
+
+**[`docs/wopr/`](docs/wopr/)** — The WOPR implementation. Concrete configuration, tool-specific commands, and working examples for every method concept.
 
 **[`docs/adoption/`](docs/adoption/)** — The bridge. [Getting started](docs/adoption/getting-started.md), [checklist](docs/adoption/checklist.md), [migration guide](docs/adoption/migration-guide.md).
 

--- a/docs/method/gates/gate-taxonomy.md
+++ b/docs/method/gates/gate-taxonomy.md
@@ -25,7 +25,17 @@ Gates are not suggestions, warnings, or "consider this" comments. They are hard 
 
 Timeout is not failure. A gate that hasn't resolved yet has not said no. The worker calls report again after a delay. The gate may pass on the next attempt.
 
-Each outcome has a different prompt source — see the [worker protocol](../pipeline/worker-protocol.md) for the full prompt resolution model.
+Each outcome has a different prompt source:
+
+| Outcome | Prompt source |
+|---------|--------------|
+| Pass | Next state's `promptTemplate` — the flow defines what comes next |
+| Fail | Gate's `failure_prompt` — the flow author defines what the worker should know |
+| Timeout | Gate's `timeout_prompt` — the flow author defines what the worker should do while waiting |
+
+Gates and flows can define `failure_prompt` and `timeout_prompt` as Handlebars templates with access to `entity`, `gate.output`, and `flow` context. Gate-level overrides flow-level. Without a configured prompt, fail returns raw gate output and timeout returns a generic "not an error, call again" message.
+
+See [worker-protocol.md](../pipeline/worker-protocol.md) for how workers respond to each outcome.
 
 ---
 
@@ -220,3 +230,13 @@ You don't need all 11 categories on day one. Start with what you have:
 - [ ] Post-deploy verification
 
 Each gate you add reduces the surface area of problems that can reach production.
+
+---
+
+## Related: State onEnter Hooks
+
+Gates block *transitions* between states. A related primitive — `onEnter` — runs *before the first claim* on a state. When an entity enters a state with an `onEnter` configured, the engine runs a setup command, merges the output into entity artifacts, and only then makes the entity claimable.
+
+Use `onEnter` for environment provisioning: creating a git worktree, spinning up a container, reserving a resource. The setup outlives the worker — if a worker idles and the entity is reclaimed, the next worker gets the same artifacts and can continue.
+
+`onEnter` is not a gate. It does not block a transition. It prepares the environment for work to begin.

--- a/docs/method/pipeline/disciplines.md
+++ b/docs/method/pipeline/disciplines.md
@@ -1,0 +1,199 @@
+# Disciplines
+
+How agentic pipelines are organized around types of minds, not types of tasks.
+
+---
+
+## What a Discipline Is
+
+A discipline is a category of work that requires a consistent type of mind. Not a task. Not a state. A mind.
+
+Engineering work requires a mind that can read a codebase, write code, review diffs, and fix findings. DevOps work requires a mind that understands infrastructure, deployment, and incident response. QA work requires a mind that thinks adversarially about correctness and coverage. Security work requires a mind that thinks adversarially about attack surface.
+
+These are fundamentally different orientations. A worker declares which orientation they have. The pipeline routes work to them accordingly.
+
+---
+
+## Discipline vs Task
+
+The discipline model inverts the traditional "assign task to specialist" pattern.
+
+Traditional model: the pipeline defines who does each step. An architect writes the spec. A coder implements it. A reviewer reviews it. A merger merges it. Each is a separate role with a separate worker.
+
+Discipline model: the pipeline defines what discipline each flow requires. An engineering worker does all of it — architecturing, coding, reviewing, fixing, merging. They own the entity from start to finish via sequential `report` calls. The state changes. The worker doesn't.
+
+```
+Traditional:
+  backlog → [architect] → [coder] → [reviewer] → [fixer] → [merger] → done
+  (5 different workers, 5 handoffs, 5 context reloads)
+
+Discipline model:
+  backlog → [engineering worker] → done
+  (1 worker, 0 handoffs, context accumulated across all states)
+```
+
+This is not a simplification. It is correct modeling. An engineer IS an architect, coder, reviewer, fixer, and merger. These are not separate professions — they are tasks within one profession. Separating them into distinct roles creates artificial handoffs that destroy context and waste tokens.
+
+---
+
+## The Four Canonical Disciplines
+
+### Engineering
+
+**Handles:** Building software — specifying, implementing, reviewing, fixing, merging.
+
+**Flow shape:** Pull-based. Entities accumulate in a backlog from the issue tracker. Engineering workers call `claim` to pull the highest-priority available entity.
+
+**Initial state:** `backlog` — entities sit here until claimed.
+
+**Triggered by:** Human decisions — someone creates an issue, files a bug, requests a feature.
+
+### DevOps
+
+**Handles:** Running software — deploying, monitoring, responding to incidents, managing infrastructure.
+
+**Flow shape:** Push-based. Entities are created by external events. A release tag is cut, a production alert fires, a deploy is requested.
+
+**Initial state:** Named after the triggering event — `release_cut`, `triggered`, `deploy_requested`.
+
+**Triggered by:** External systems — CI completes, monitoring alerts, release automation fires.
+
+### QA
+
+**Handles:** Verifying software — authoring tests, executing test suites, analyzing regressions, closing coverage gaps.
+
+**Flow shape:** Push-based. Entities are created when coverage gaps are detected or test targets are identified.
+
+**Initial state:** `test_target`, `coverage_gap`.
+
+**Triggered by:** Coverage analysis, audit findings, post-deploy verification failures.
+
+### Security
+
+**Handles:** Protecting software — auditing code, remediating vulnerabilities, assessing attack surface, triaging CVEs.
+
+**Flow shape:** Push-based. Entities are created by security scanners, CVE databases, or audit reports.
+
+**Initial state:** `finding`, `cve_triaged`.
+
+**Triggered by:** Dependency audits, scheduled security scans, CVE database updates.
+
+---
+
+## How Discipline Routing Works
+
+Flows declare their discipline. Workers declare their discipline. DEFCON matches them.
+
+```
+Flow definition:
+  { "name": "wopr-changeset", "discipline": "engineering", ... }
+
+Worker claim:
+  flow.claim({ workerId: "wkr_abc123", role: "engineering" })
+
+DEFCON:
+  find all flows where discipline = "engineering"
+  find highest-priority claimable entity across those flows
+  return it
+```
+
+The worker never specifies which flow or which entity. DEFCON picks. This is not just a convenience — it is the mechanism that prevents workers from gaming priority. A worker that could choose its own entity could choose easy work, skip difficult entities, or pick things out of priority order.
+
+States do not have roles. The flow has a discipline. Every entity in an engineering flow is claimable by any engineering worker.
+
+---
+
+## Flow Shapes by Discipline
+
+```
+Engineering (pull-based):
+
+  [Linear issue created]
+       |
+       v
+    backlog  <-- engineering workers pull from here
+       |
+  architecting
+       |
+    coding
+       |
+   reviewing
+       |
+   fixing (if issues)
+       |
+   merging
+       |
+     done
+
+
+DevOps (push-based):
+
+  [GitHub tag created]
+       |
+       v
+  release_cut  <-- entity created by webhook
+       |
+  staging_deploy
+       |
+  smoke_test
+       |
+  production_deploy
+       |
+  health_check
+       |
+     done
+
+
+Security (push-based):
+
+  [CVE detected in dependency]
+       |
+       v
+    finding  <-- entity created by audit runner
+       |
+   assessing
+       |
+  remediating
+       |
+   verifying
+       |
+     done
+```
+
+---
+
+## Cross-Discipline Flows
+
+Some workflows span disciplines — build the thing, then deploy it. The recommended pattern is **split flows**: engineering flow ends at `merging`, a devops flow starts when the merge event triggers.
+
+```
+Engineering flow ends:  ...→ merging → done
+                                          |
+                                     [merge event]
+                                          |
+DevOps flow starts:               deploy_triggered → ...
+```
+
+This keeps each flow single-discipline, clean, and independently manageable. Engineering workers never get devops prompts. DevOps workers never see the coding backlog.
+
+---
+
+## Adding New Disciplines
+
+Disciplines are extensible. A flow author can define any discipline by declaring it on the flow:
+
+```json
+{ "name": "ml-training", "discipline": "ml-engineering" }
+```
+
+Workers calling `flow.claim(role: "ml-engineering")` will receive entities from that flow. The four canonical disciplines are defaults, not constraints.
+
+---
+
+See [worker-protocol.md](worker-protocol.md) for how `flow.claim` uses discipline to route work.
+
+See [lifecycle.md](lifecycle.md) for where disciplines fit in the full agentic engineering cycle.
+
+See [event-ingestion.md](event-ingestion.md) for how push-triggered discipline flows receive entities from external events.
+
+See [WOPR implementation](../../wopr/pipeline/disciplines.md).

--- a/docs/method/pipeline/event-ingestion.md
+++ b/docs/method/pipeline/event-ingestion.md
@@ -1,0 +1,138 @@
+# Event Ingestion
+
+How push-triggered discipline flows receive entities from external events.
+
+---
+
+## Pull vs Push
+
+Not all pipelines start the same way.
+
+**Pull-based flows** (engineering): entities pre-exist in a backlog. Workers call `claim` when they're ready to work. The pipeline waits for workers. Work accumulates and gets consumed at the pace workers can handle it.
+
+**Push-based flows** (devops, qa, security): entities are created by external events. A release is cut, a production alert fires, a CVE is published, a coverage gap is detected. The pipeline must react immediately. There is no backlog — each event creates one entity, right now.
+
+The distinction matters because the two models have different failure modes:
+- Pull-based: backlog grows if workers are too slow. The queue is the buffer.
+- Push-based: events are missed if ingestion is unavailable. The webhook is the entry point.
+
+---
+
+## The Event Contract
+
+Every push-triggered entity creation requires:
+
+1. **Target flow** — which flow should handle this event
+2. **Event type** — what kind of event occurred (flow must declare it accepts this type)
+3. **Refs** — structured references to external resources (repository, issue, alert ID)
+4. **Artifacts** — initial data the workers will need (version number, environment, findings)
+
+The entity starts life with this context already attached. Workers get it immediately on `claim` — no need to re-fetch from the originating system.
+
+---
+
+## Webhook Pattern
+
+External systems POST events to the pipeline's webhook endpoint:
+
+```
+POST /webhook/:flowName
+{
+  "event": "release_cut",
+  "refs": {
+    "github": { "repo": "org/repo", "tag": "v1.4.2", "sha": "abc123" }
+  },
+  "artifacts": {
+    "releaseVersion": "v1.4.2",
+    "targetEnv": "production"
+  }
+}
+```
+
+The pipeline:
+1. Validates the request signature (HMAC — see Security below)
+2. Checks that the flow accepts this event type
+3. Creates an entity in the flow's `initialState` with the provided refs and artifacts
+4. Returns the entity ID
+
+A worker calling `claim(role: "devops")` will receive the entity. Its prompt will have `releaseVersion` and all other artifacts available as `{{entity.artifacts.releaseVersion}}`.
+
+---
+
+## CLI Trigger
+
+For manual or scripted entity creation without a webhook integration:
+
+```bash
+pipeline trigger --flow wopr-release \
+  --event release_cut \
+  --refs '{"github": {"repo": "org/repo", "tag": "v1.4.2"}}' \
+  --artifacts '{"releaseVersion": "v1.4.2"}'
+```
+
+This calls the same internal entity-creation logic as the webhook — not a separate code path. Useful for testing flows, manual intervention, or scripted automation that doesn't have a webhook target.
+
+---
+
+## Flow Configuration
+
+Flows must declare which event types they accept:
+
+```json
+{
+  "name": "my-release-flow",
+  "discipline": "devops",
+  "initialState": "release_cut",
+  "acceptsEvents": ["release_cut"]
+}
+```
+
+Events not in `acceptsEvents` are rejected with a clear error. This prevents misconfigured webhooks from silently creating entities in the wrong flow.
+
+---
+
+## Idempotency
+
+External systems frequently deliver the same event more than once — network retries, delivery guarantees, duplicate webhook registrations. The pipeline must handle this gracefully.
+
+Flows declare a deduplication key:
+
+```json
+{
+  "deduplicationKey": "refs.github.tag"
+}
+```
+
+If an entity already exists with the same deduplication key value, the webhook returns the existing entity ID instead of creating a new one. The second delivery is a no-op. Workers are unaffected.
+
+Without a deduplication key, every webhook delivery creates a new entity — appropriate for truly distinct events (each alert, each CVE), not for events that should be idempotent (each release tag).
+
+---
+
+## Security
+
+All webhook endpoints require authentication via HMAC signature:
+
+```
+X-Pipeline-Signature: sha256=<hmac-sha256 of request body>
+```
+
+Per-flow secrets are configured in the pipeline — the sending system must know the secret to produce a valid signature. Requests with missing or invalid signatures are rejected with 401.
+
+This is a server-to-server integration. The webhook endpoint is not a public API.
+
+---
+
+## Engineering Flows Are Different
+
+Engineering flows do not use event ingestion. Entities are created by the issue tracker sync — when an issue is created in Linear (or equivalent), a corresponding entity is created in the engineering flow's backlog.
+
+Event ingestion is for the other disciplines. Engineering starts with human intent expressed as an issue. DevOps, QA, and security start with system events that require response.
+
+---
+
+See [disciplines.md](disciplines.md) for why devops, qa, and security flows are push-triggered.
+
+See [worker-protocol.md](worker-protocol.md) for how workers claim entities once they exist.
+
+See [WOPR implementation](../../wopr/pipeline/event-ingestion.md).

--- a/docs/method/pipeline/worker-protocol.md
+++ b/docs/method/pipeline/worker-protocol.md
@@ -17,6 +17,75 @@ This is not a limitation. It's the point. An agent that knows "if I say X, we sk
 
 ---
 
+## Disciplines and Claiming
+
+Workers declare a **discipline** — what kind of mind they are, not what task they will perform.
+
+`claim(role: "engineering")` means: I am an engineering mind. Give me engineering work. The pipeline finds all flows with `discipline: "engineering"`, finds the highest-priority claimable entity across all of them, and returns it. The worker never picks. The pipeline picks.
+
+An engineering worker IS the architect, coder, reviewer, fixer, and merger. These are not separate roles — they are states within one discipline. The worker owns the entity end-to-end via sequential `report` calls. The state changes. The worker doesn't.
+
+Flows declare their discipline. States do not have roles.
+
+See [disciplines.md](disciplines.md) for the full discipline model.
+
+---
+
+## When No Work Is Available
+
+`claim` never returns bare null. When no work is available, it returns a structured response:
+
+```
+{
+  next_action: "check_back",
+  retry_after_ms: 30000,
+  message: "No work available. 3 entities are active but all claimed. Call claim again after the retry delay."
+}
+```
+
+Same semantics as a gate timeout on `report`. The worker waits and retries. Two situations produce different retry delays: all entities claimed (short retry, 30s — something will free up) vs empty backlog (long retry, 5min — no work exists right now).
+
+### The Canonical Worker Loop
+
+```
+loop:
+  response = claim(role, workerId)
+
+  if response.next_action == "check_back":
+    wait(response.retry_after_ms)
+    continue
+
+  # Got work — stay on this entity until done or gated
+  while true:
+    # do work per response.prompt
+    response = report(workerId, entityId, signal, artifacts)
+
+    if response.next_action == "waiting":
+      break  # entity gated — return to claim loop
+
+    if response.next_action == "check_back":
+      wait(response.retry_after_ms)
+      continue  # re-report with same arguments
+
+    # next_action == "continue" — new prompt, continue loop
+```
+
+---
+
+## Worker Affinity
+
+When a worker reports, the entity records their identity. If the entity re-enters a claimable state within the same discipline, it is **reserved** for that worker for `affinity_window_ms` (default 5 minutes). The worker gets it back on next `claim` — ahead of other eligible workers.
+
+Affinity matters primarily in two cases:
+1. **Worker idles mid-work** — reaper releases the claim. Worker comes back, affinity returns the entity.
+2. **Discipline boundary handoff** — entity crosses from engineering to devops. The devops worker that picks it up gets affinity for the devops phase.
+
+Within a normal run (one claim, sequential reports), affinity is never exercised — the worker never releases the entity.
+
+Affinity expires if the worker doesn't claim within the window. The entity enters the open pool.
+
+---
+
 ## Workers
 
 Any process that can make two calls is a valid worker:
@@ -141,3 +210,7 @@ This model inverts that. Workers pull work via claim. Gates pull verdicts via re
 That inversion makes workers composable. A human, an agent, a script — all can participate in the same pipeline because they all speak the same two-call protocol. The pipeline doesn't care what's on the other end of the call. It cares that the call is made.
 
 See [WOPR implementation](../../wopr/pipeline/worker-protocol.md) for concrete schema and configuration.
+
+See [disciplines.md](disciplines.md) for how discipline routing determines which entities a worker receives.
+
+See [gate-taxonomy.md](../gates/gate-taxonomy.md) for the full gate outcome model.

--- a/docs/wopr/pipeline/disciplines.md
+++ b/docs/wopr/pipeline/disciplines.md
@@ -1,0 +1,136 @@
+# Disciplines — DEFCON Implementation
+
+The concrete implementation of the [discipline model](../../method/pipeline/disciplines.md) in DEFCON.
+
+---
+
+## WOPR's Four Disciplines
+
+### engineering
+
+The primary DEFCON discipline. An engineering worker owns a `wopr-changeset` entity from backlog through merge.
+
+```
+flow.claim({ workerId: "wkr_abc123", role: "engineering" })
+→ entity feat-392 in state "architecting"
+→ prompt: "Write an implementation spec for WOP-392..."
+
+flow.report({ workerId: "wkr_abc123", signal: "spec_ready" })
+→ gate: spec-posted (did the spec land in Linear?)
+→ entity advances to "coding"
+→ prompt: "Implement the spec. Worktree: ~/worktrees/WOP-392..."
+
+flow.report({ workerId: "wkr_abc123", signal: "pr_created", artifacts: { prUrl: "..." } })
+→ gate: ci-green (CI must pass before review)
+→ entity advances to "reviewing"
+→ prompt: "Review the PR. Check CI, read bot comments, read the diff..."
+
+... and so on through fixing, merging, done.
+```
+
+One worker. One claim. Sequential reports. The engineering worker IS the architect, coder, reviewer, fixer, and merger.
+
+### devops
+
+Handles WOPR releases, deploys, and production incidents. Push-triggered — entities are created by GitHub webhooks (release tags) or monitoring alerts (PagerDuty).
+
+Future flows:
+- `wopr-release` — triggered by GitHub tag, handles staging → production deploy
+- `wopr-incident` — triggered by PagerDuty alert, handles investigation → mitigation → postmortem
+
+### qa
+
+Handles test authoring, coverage gap remediation, and post-deploy verification failures. Push-triggered by coverage analysis and audit findings.
+
+Future flow: `wopr-qa-coverage` — triggered by coverage threshold breach.
+
+### security
+
+Handles CVE remediation, dependency audits, and security findings. Push-triggered by `npm audit`, Snyk, or scheduled scans.
+
+Future flow: `wopr-security-audit` — triggered by scheduled scan finding high-severity CVEs.
+
+---
+
+## Flow Seed Format
+
+The `discipline` field is required on every flow. States do not declare roles.
+
+```json
+{
+  "flows": [
+    {
+      "name": "wopr-changeset",
+      "discipline": "engineering",
+      "initialState": "backlog",
+      "maxConcurrent": 4,
+      "defaultModelTier": "sonnet"
+    }
+  ],
+  "states": [
+    {
+      "name": "architecting",
+      "flowName": "wopr-changeset",
+      "modelTier": "opus",
+      "mode": "active",
+      "promptTemplate": "..."
+    },
+    {
+      "name": "coding",
+      "flowName": "wopr-changeset",
+      "modelTier": "sonnet",
+      "mode": "active",
+      "promptTemplate": "..."
+    }
+  ]
+}
+```
+
+Note: `modelTier` on states is for **active mode model selection only** — it tells DEFCON what model to spawn when running autonomously. It has nothing to do with discipline routing. Passive workers use whatever model they are.
+
+If a seed file contains `agentRole` on any state, the loader will reject it with an error — that field has been removed.
+
+---
+
+## Claim Routing
+
+`flow.claim(role: "engineering")` queries:
+
+```sql
+SELECT entities.*
+FROM entities
+JOIN flows ON entities.flow_id = flows.id
+WHERE flows.discipline = 'engineering'
+  AND entities.claimed_by IS NULL
+  AND entities.status = 'active'
+ORDER BY
+  -- Affinity: prefer entities this worker last touched
+  CASE WHEN entities.affinity_worker_id = :workerId
+       AND entities.affinity_expires_at > NOW()
+  THEN 0 ELSE 1 END,
+  -- Then priority from issue tracker
+  entities.priority,
+  -- Then time in current state
+  entities.entered_state_at
+LIMIT 1
+```
+
+The worker never sees devops or security entities. The discipline filter is the boundary.
+
+---
+
+## Adding a New Discipline Flow
+
+1. Create a seed file with `"discipline": "your-discipline"` on the flow
+2. Set `initialState` to reflect the trigger (e.g. `"alert_fired"` for an incident flow)
+3. If push-triggered, add `"acceptsEvents": ["your-event-type"]`
+4. Load with `defcon init --seed seeds/your-flow.json`
+5. Workers call `flow.claim({ role: "your-discipline" })` to receive work
+
+See [seeds/wopr-changeset.json](../../../seeds/wopr-changeset.json) for the canonical engineering flow example.
+
+---
+
+See [method/disciplines.md](../../method/pipeline/disciplines.md) for the principle.
+
+See [worker-protocol.md](worker-protocol.md) for how claim routing works end-to-end.

--- a/docs/wopr/pipeline/event-ingestion.md
+++ b/docs/wopr/pipeline/event-ingestion.md
@@ -1,0 +1,143 @@
+# Event Ingestion — DEFCON Implementation
+
+The concrete implementation of [event ingestion](../../method/pipeline/event-ingestion.md) in DEFCON.
+
+---
+
+## The Webhook Endpoint
+
+```
+POST /webhook/:flowName
+Headers:
+  X-DEFCON-Signature: sha256=<hmac-sha256 of request body>
+  Content-Type: application/json
+```
+
+Example — release webhook from GitHub Actions:
+
+```json
+{
+  "event": "release_cut",
+  "refs": {
+    "github": {
+      "repo": "wopr-network/wopr",
+      "tag": "v1.4.2",
+      "sha": "abc123def456"
+    }
+  },
+  "artifacts": {
+    "releaseVersion": "v1.4.2",
+    "targetEnv": "production",
+    "changelogUrl": "https://github.com/wopr-network/wopr/releases/tag/v1.4.2"
+  }
+}
+```
+
+Response (201 Created):
+
+```json
+{
+  "entityId": "rel-42",
+  "flow": "wopr-release",
+  "state": "release_cut",
+  "message": "Entity created. A devops worker will pick it up on next claim."
+}
+```
+
+---
+
+## CLI Trigger
+
+For manual triggering or scripted automation:
+
+```bash
+defcon trigger --flow wopr-release \
+  --event release_cut \
+  --refs '{"github": {"repo": "wopr-network/wopr", "tag": "v1.4.2"}}' \
+  --artifacts '{"releaseVersion": "v1.4.2", "targetEnv": "production"}'
+```
+
+Same internal code path as the webhook. No difference in entity creation behavior.
+
+---
+
+## HMAC Signature Verification
+
+Signatures use SHA-256 HMAC over the raw request body:
+
+```typescript
+// Sending system generates:
+const signature = `sha256=${crypto
+  .createHmac('sha256', WEBHOOK_SECRET)
+  .update(rawBody)
+  .digest('hex')}`
+
+// DEFCON verifies:
+const expected = `sha256=${crypto
+  .createHmac('sha256', flowSecret)
+  .update(rawBody)
+  .digest('hex')}`
+crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+```
+
+Per-flow secrets are configured in DEFCON config or environment variables:
+
+```bash
+DEFCON_WEBHOOK_SECRET_WOPR_RELEASE=your-secret-here
+```
+
+---
+
+## Flow Configuration for Event Ingestion
+
+```json
+{
+  "name": "wopr-release",
+  "discipline": "devops",
+  "initialState": "release_cut",
+  "acceptsEvents": ["release_cut"],
+  "deduplicationKey": "refs.github.tag"
+}
+```
+
+- `acceptsEvents` — whitelist of allowed event types. Unknown types → 400 error.
+- `deduplicationKey` — dot-path into the payload to extract the dedup value. Prevents duplicate entities from repeated webhook deliveries.
+
+---
+
+## Wiring GitHub Actions → DEFCON
+
+In `.github/workflows/release.yml`:
+
+```yaml
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-defcon:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger DEFCON
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg tag "${{ github.event.release.tag_name }}" \
+            --arg sha "${{ github.sha }}" \
+            --arg repo "${{ github.repository }}" \
+            '{event: "release_cut", refs: {github: {repo: $repo, tag: $tag, sha: $sha}}, artifacts: {releaseVersion: $tag, targetEnv: "production"}}')
+
+          SIG="sha256=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "${{ secrets.DEFCON_WEBHOOK_SECRET }}" | awk '{print $2}')"
+
+          curl -X POST "${{ secrets.DEFCON_URL }}/webhook/wopr-release" \
+            -H "Content-Type: application/json" \
+            -H "X-DEFCON-Signature: $SIG" \
+            -d "$PAYLOAD"
+```
+
+---
+
+See [method/event-ingestion.md](../../method/pipeline/event-ingestion.md) for the principle.
+
+See [disciplines.md](disciplines.md) for why devops flows need event ingestion.
+
+See [worker-protocol.md](worker-protocol.md) for how devops workers claim and process these entities.

--- a/docs/wopr/pipeline/worker-protocol.md
+++ b/docs/wopr/pipeline/worker-protocol.md
@@ -13,30 +13,44 @@ DEFCON exposes the worker protocol as two MCP tools:
 ```json
 {
   "workerId": "wkr_abc123",
-  "agentRole": "reviewer"
+  "role": "engineering",
+  "flow": "wopr-changeset"
 }
 ```
 
-Both fields are optional. If `workerId` is omitted, DEFCON auto-registers a new worker and returns the ID in the response — the worker must carry it forward on every subsequent call.
-
-`agentRole` filters claims to invocations matching that role. Omit to claim any available work.
+- `workerId` — required after first call. Omit on first call only — DEFCON auto-registers and returns a new ID with a prominent notice.
+- `role` — discipline: `"engineering"`, `"devops"`, `"qa"`, or `"security"`. Routes claim to matching flows.
+- `flow` — optional. Restrict to one flow. Omit to claim across all flows in the discipline.
 
 **Response (work available):**
 ```json
 {
+  "workerId": "wkr_abc123",
   "entityId": "feat-392",
   "invocationId": "inv_xyz",
-  "stage": "reviewing",
-  "prompt": "Check CI on the PR at https://github.com/...",
-  "workerId": "wkr_abc123"
+  "flow": "wopr-changeset",
+  "stage": "architecting",
+  "prompt": "You are the engineering worker for feat-392..."
 }
 ```
 
 **Response (no work available):**
 ```json
 {
+  "next_action": "check_back",
+  "retry_after_ms": 30000,
+  "message": "No work available for discipline 'engineering'. Call flow.claim again after the retry delay."
+}
+```
+
+**Response (first call, no workerId):**
+```json
+{
+  "worker_notice": "NO WORKER ID PROVIDED. A worker has been registered: wkr_abc123. YOU MUST pass workerId: \"wkr_abc123\" in ALL future flow calls. Omitting it will register a new worker each time.",
   "workerId": "wkr_abc123",
-  "invocation": null
+  "entityId": "feat-392",
+  "stage": "architecting",
+  "prompt": "..."
 }
 ```
 
@@ -209,13 +223,13 @@ The MCP client must not apply a short HTTP timeout to `flow.report`. The stdio t
 ## Spawning a Claude Code Session as a Worker
 
 ```bash
-defcon worker new --role reviewer --idle-timeout 1800
+defcon worker new --role engineering --idle-timeout 1800
 ```
 
 This registers a new worker and opens a Claude Code session with a rendered prompt:
 
 ```
-You are DEFCON worker wkr_abc123. Role: reviewer.
+You are DEFCON worker wkr_abc123. Discipline: engineering.
 Connected to DEFCON at <mcpUrl> via MCP.
 
 Use flow.claim to pick up available work, perform the task, then use
@@ -224,6 +238,12 @@ flow.report to submit your result. Pass your workerId in every call.
 Keep claiming until no work is available or you are told to stop.
 ```
 
-The human drives the session. DEFCON sees a registered worker. The claim/report protocol is identical to any other worker. The pipeline does not know or care that there's a human making the decisions.
+The human drives the session. DEFCON sees a registered worker with discipline `engineering`. The claim/report protocol is identical to any autonomous agent. The pipeline does not know or care that there's a human making the decisions.
 
-This is the mechanism for human-in-the-loop stages: define a stage with `agentRole: "human-reviewer"`, assign workers with that role to human sessions, and those stages will only be claimed by humans. The gate still runs. The escalation still holds. The human is just the one doing the work.
+Workers declare disciplines, not task roles. A human worker with `role: "engineering"` will receive architecting, coding, reviewing, fixing, and merging tasks — whatever engineering state the highest-priority entity is in.
+
+---
+
+See [disciplines.md](disciplines.md) for how discipline routing works.
+
+See [../../method/pipeline/worker-protocol.md](../../method/pipeline/worker-protocol.md) for the tool-agnostic protocol.

--- a/seeds/wopr-changeset.json
+++ b/seeds/wopr-changeset.json
@@ -3,6 +3,7 @@
     {
       "name": "wopr-changeset",
       "description": "WOPR continuous delivery pipeline: architect -> code -> review -> fix -> merge. Replaces the hand-coded /wopr:auto skill.",
+      "discipline": "engineering",
       "initialState": "backlog",
       "maxConcurrent": 4,
       "maxConcurrentPerRepo": 4,
@@ -18,7 +19,6 @@
     {
       "name": "architecting",
       "flowName": "wopr-changeset",
-      "agentRole": "wopr-architect",
       "modelTier": "opus",
       "mode": "active",
       "promptTemplate": "Your name is \"architect-{{entity.refs.linear.id}}\". You are on the {{flow.name}} team.\n\n## YOUR ROLE — READ ONLY\nYou are a spec writer, NOT a coder. Do NOT create, edit, or write any code files.\nDo NOT create branches, worktrees, or PRs. Do NOT run git checkout or git commit.\nYour ONLY deliverable is an implementation spec posted as a Linear comment.\nRead the codebase at the path below for context only. Then post your spec and send \"Spec ready: {{entity.refs.linear.key}}\" to team-lead.\n\n## Assignment\nIssue: {{entity.refs.linear.key}} — {{entity.refs.linear.title}}\nLinear ID: {{entity.refs.linear.id}}\nRepo: {{entity.refs.github.repo}}\nCodebase (READ ONLY): {{entity.artifacts.codebasePath}}\n\n## Issue Description\n{{entity.refs.linear.description}}\n\n## Deliverable\nPost a detailed implementation spec as a Linear comment on the issue. The spec must include:\n1. Exact files to create/modify with full paths\n2. Function signatures and data structures\n3. Step-by-step implementation tasks (TDD: failing test first, then implementation)\n4. Edge cases and gotchas from CLAUDE.md and codebase analysis\n5. Exact test commands and commit messages per task\n\nThen send to team-lead: \"Spec ready: {{entity.refs.linear.key}}\""
@@ -26,7 +26,6 @@
     {
       "name": "coding",
       "flowName": "wopr-changeset",
-      "agentRole": "wopr-coder",
       "modelTier": "sonnet",
       "mode": "active",
       "promptTemplate": "Your name is \"coder-{{entity.refs.linear.id}}\". You are on the {{flow.name}} team.\n\n## Assignment\nIssue: {{entity.refs.linear.key}} — {{entity.refs.linear.title}}\nRepo: {{entity.refs.github.repo}}\nWorktree: {{entity.artifacts.worktreePath}}\nBranch: {{entity.artifacts.branch}}\n\n{{#if entity.artifacts.gate_failures}}\n## Prior Gate Failures — Address These\n{{#each entity.artifacts.gate_failures}}\n- **{{this.gateName}}** ({{this.failedAt}}): {{this.output}}\n{{/each}}\n{{/if}}\n\n## Step 1: Read the architect spec\nFetch comments from Linear issue {{entity.refs.linear.id}} and find the implementation spec posted by the architect.\n\n## Step 2: Follow the spec\nWork in the worktree at {{entity.artifacts.worktreePath}}. Follow the spec step by step:\n1. Write the failing test first\n2. Implement minimal code to pass the test\n3. Run targeted tests: `npx vitest run <test-file>` — NEVER `pnpm test` in worktrees (OOMs)\n4. Commit after each green task\n\n## Step 3: Create PR\n```bash\ncd {{entity.artifacts.worktreePath}}\ngit push -u origin {{entity.artifacts.branch}}\ngh pr create --repo {{entity.refs.github.repo}} \\\n  --title \"feat: {{entity.refs.linear.title}} ({{entity.refs.linear.key}})\" \\\n  --body \"Closes {{entity.refs.linear.key}}\"\n```\n\n## Completion\nSend to team-lead: \"PR created: <PR_URL> for {{entity.refs.linear.key}}\""
@@ -34,7 +33,6 @@
     {
       "name": "reviewing",
       "flowName": "wopr-changeset",
-      "agentRole": "wopr-reviewer",
       "modelTier": "sonnet",
       "mode": "active",
       "promptTemplate": "Your name is \"reviewer-{{entity.refs.linear.id}}\". You are on the {{flow.name}} team.\n\n## Assignment\nPR: {{entity.artifacts.prUrl}} (#{{entity.artifacts.prNumber}})\nIssue: {{entity.refs.linear.key}}\nRepo: {{entity.refs.github.repo}}\n\n{{#if entity.artifacts.gate_failures}}\n## Prior Gate Failures — Address These\n{{#each entity.artifacts.gate_failures}}\n- **{{this.gateName}}** ({{this.failedAt}}): {{this.output}}\n{{/each}}\n{{/if}}\n\n## Step 1: Wait for review bots\n```bash\n~/wopr-await-reviews.sh {{entity.artifacts.prNumber}} {{entity.refs.github.repo}}\n```\n\n## Step 2: Check CI status\n```bash\ngh pr checks {{entity.artifacts.prNumber}} --repo {{entity.refs.github.repo}}\n```\nIf ANY check is FAILING, report ISSUES immediately — no code review needed.\n\n## Step 3: Read ALL review comments\n```bash\n# Inline comments (WHERE QODO /improve SUGGESTIONS APPEAR)\ngh api repos/{{entity.refs.github.repo}}/pulls/{{entity.artifacts.prNumber}}/comments \\\n  --jq '.[] | \"[\\(.user.login)] \\(.path):\\(.line // \"?\") — \\(.body)\"'\n\n# Formal reviews\ngh pr view {{entity.artifacts.prNumber}} --repo {{entity.refs.github.repo}} --json reviews \\\n  --jq '.reviews[]? | \"[\\(.author.login) / \\(.state)] \\(.body)\"'\n\n# Top-level comments\ngh api repos/{{entity.refs.github.repo}}/issues/{{entity.artifacts.prNumber}}/comments \\\n  --jq '.[] | \"[\\(.user.login)] \\(.body)\"'\n```\n\nIMPORTANT: ALWAYS call `gh api repos/.../pulls/N/comments` for inline comments.\nIf a Qodo comment has `line: null`, it is outdated — reply to resolve it, do NOT treat as blocking.\nNEVER declare CLEAN if Qodo has any open /improve suggestions on current code.\n\n## Step 4: Read the diff\n```bash\ngh pr diff {{entity.artifacts.prNumber}} --repo {{entity.refs.github.repo}}\n```\n\n## Step 5: Render verdict\n- If all CI green AND no actionable findings: \"CLEAN: {{entity.artifacts.prUrl}}\"\n- If issues found: \"ISSUES: {{entity.artifacts.prUrl}} — <finding1>; <finding2>\"\n\n## Signal Format\nEnd your message to team-lead with exactly one of:\n- \"CLEAN: <pr-url>\" — if all checks pass and no findings\n- \"ISSUES: <pr-url> — <finding1>; <finding2>\" — if any issues found"
@@ -42,7 +40,6 @@
     {
       "name": "fixing",
       "flowName": "wopr-changeset",
-      "agentRole": "wopr-fixer",
       "modelTier": "sonnet",
       "mode": "active",
       "promptTemplate": "Your name is \"fixer-{{entity.refs.linear.id}}\". You are on the {{flow.name}} team.\n\n## Assignment\nPR: {{entity.artifacts.prUrl}} (#{{entity.artifacts.prNumber}})\nIssue: {{entity.refs.linear.key}}\nRepo: {{entity.refs.github.repo}}\nWorktree: {{entity.artifacts.worktreePath}}\nBranch: {{entity.artifacts.branch}}\n\n{{#if entity.artifacts.gate_failures}}\n## Prior Gate Failures — Address These\n{{#each entity.artifacts.gate_failures}}\n- **{{this.gateName}}** ({{this.failedAt}}): {{this.output}}\n{{/each}}\n{{/if}}\n\n## Step 1: Rebase before touching anything\n```bash\ncd {{entity.artifacts.worktreePath}}\ngit fetch origin\ngit rebase origin/main\n```\nIf rebase conflicts and you cannot resolve: send \"Can't resolve: {{entity.artifacts.prUrl}} — rebase conflict in <filename>: <description>\"\n\n## Step 2: Fix the findings\n\n### Reviewer Findings\n{{entity.artifacts.reviewFindings}}\n\nAddress each finding. Run targeted tests after each fix: `npx vitest run <test-file>`\n\n## Step 3: Push fixes\n```bash\ngit add <specific-files>\ngit commit -m \"fix: address review findings\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\"\ngit push origin {{entity.artifacts.branch}}\n```\n\n## Completion\nSend to team-lead: \"Fixes pushed: {{entity.artifacts.prUrl}}\""
@@ -50,7 +47,6 @@
     {
       "name": "merging",
       "flowName": "wopr-changeset",
-      "agentRole": "watcher",
       "modelTier": "haiku",
       "mode": "active",
       "promptTemplate": "Your name is \"watcher-{{entity.refs.linear.id}}\". You are on the {{flow.name}} team.\n\nRun ~/wopr-pr-watch.sh {{entity.artifacts.prNumber}} {{entity.refs.github.repo}} and report the result.\n\n- If MERGED: send \"Merged: {{entity.artifacts.prUrl}} for {{entity.refs.linear.key}}\"\n- If BLOCKED: send \"BLOCKED: {{entity.artifacts.prUrl}} for {{entity.refs.linear.key}} — CI failing: <checks>\"\n- If CLOSED: send \"CLOSED: {{entity.artifacts.prUrl}} for {{entity.refs.linear.key}}\"\n- If TIMEOUT: send \"TIMEOUT: {{entity.artifacts.prUrl}} for {{entity.refs.linear.key}}\""


### PR DESCRIPTION
## Summary

Captures the complete architecture for the discipline-based worker model before it gets implemented. This PR is the institutional knowledge that WOP-1897 (comprehensive docs update) called for.

### What changed

**New docs:**
- `docs/method/pipeline/disciplines.md` — the discipline model: flows own disciplines, states have no roles, workers declare disciplines. An engineering worker IS architect+coder+reviewer+fixer+merger — one claim, sequential reports end-to-end.
- `docs/method/pipeline/event-ingestion.md` — pull vs push distinction, webhook pattern, engineering flows pull from backlog, devops/qa/security push from external events
- `docs/wopr/pipeline/disciplines.md` — WOPR-specific: four disciplines, wopr-changeset as canonical engineering flow, seed format, claim routing
- `docs/wopr/pipeline/event-ingestion.md` — webhook endpoint, HMAC verification, GitHub Actions wiring

**Updated docs:**
- `docs/method/pipeline/worker-protocol.md` — added disciplines, canonical worker loop, worker affinity, null claim = check_back
- `docs/wopr/pipeline/worker-protocol.md` — flow.claim uses `role` (discipline), null claim response, defcon worker new syntax
- `docs/method/gates/gate-taxonomy.md` — failure_prompt/timeout_prompt as configurable gate fields, prompt source table, onEnter hooks section

**Updated seed:**
- `seeds/wopr-changeset.json` — added `discipline: "engineering"` on flow, removed `agentRole` from all states (discipline belongs to flow, not state)

**Updated README:**
- Discipline model explanation in "Two Calls" section
- Null claim response example
- Updated docs index

### Key architecture decisions documented

1. `claim(role: "engineering")` routes across ALL engineering flows — worker never picks
2. Three gate outcomes each have a different prompt source: pass→next state's promptTemplate, fail→gate's failure_prompt, timeout→gate's timeout_prompt
3. Worker affinity: entity reserved for last worker at discipline boundaries (5min window)
4. onEnter hooks prepare environment before first claim — not a gate, runs once per state entry
5. Engineering flows pull; devops/qa/security flows push from external events

Relates to: WOP-1890, WOP-1891, WOP-1894, WOP-1895, WOP-1896, WOP-1897, WOP-1898, WOP-1899, WOP-1900

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Document the discipline-based worker model, event-driven ingestion for non-engineering flows, and the updated worker protocol semantics across method and WOPR implementation docs, plus align seeds and README with the new architecture.

Documentation:
- Add method-level documentation for the discipline model, differentiating disciplines from tasks and outlining canonical disciplines and flow shapes.
- Add method-level documentation for push-based event ingestion, including webhook/CLI triggers, event contracts, deduplication, and security model.
- Add WOPR implementation docs for disciplines and event ingestion, detailing DEFCON-specific flows, routing, seed format, and GitHub Actions wiring.
- Extend worker protocol docs (method and WOPR) with discipline-aware claiming, canonical worker loop semantics, null-claim/check_back responses, and worker affinity behavior.
- Clarify gate taxonomy docs with explicit mapping from gate outcomes to prompt sources and add guidance on state onEnter hooks for environment setup.
- Update README to explain the discipline model, structured no-work responses from claim, and to highlight key method/WOPR documentation entry points.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document the discipline-based worker model, event ingestion flow, and updated worker protocol across README and WOPR docs
> Introduce discipline routing and worker claiming semantics, specify event ingestion contracts with HMAC and idempotency, define gate outcome prompts and state onEnter hooks, and update WOPR seeds and protocol to use `role` (discipline) instead of `agentRole` with structured no-work responses.
>
> #### 📍Where to Start
> Start with the worker protocol overview in [worker-protocol.md](https://github.com/wopr-network/defcon/pull/53/files#diff-29af746819f7799fd325e8e599e1eb5888a372e2731368d509ca8140b249acc5), then review WOPR specifics in [worker-protocol.md](https://github.com/wopr-network/defcon/pull/53/files#diff-4eb9f69cf47ab204b3305eebe811449d02f412770d7ea0efcb795f3091ce0685) and the seed changes in [wopr-changeset.json](https://github.com/wopr-network/defcon/pull/53/files#diff-013d2fba1c541f82e531a0d8e8bcf3674f9067720ac58369f65af3420ccd4629).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e5bfb55. 9 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->