### PR TITLE
docs: WarGames narrative — launch codes, Temporal comparison, full stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,10 @@ Key method docs: [worker protocol](docs/method/pipeline/worker-protocol.md) · [
 
 ## Architecture & Design Philosophy
 
-For a detailed discussion of design decisions — including why DEFCON uses earned escalation instead of Temporal's durable execution, and how WOPR, DEFCON, and NORAD connect — see [docs/design-philosophy.md](docs/design-philosophy.md).
+For design decisions — including why DEFCON uses earned escalation instead of durable execution, and how WOPR, DEFCON, and NORAD connect:
+
+- [Earned escalation vs durable execution](docs/method/manifesto/earned-escalation-vs-durable-execution.md) — tool-agnostic principle
+- [WOPR implementation: why not Temporal, and the full stack](docs/wopr/manifesto/earned-escalation-vs-durable-execution.md) — concrete specifics
 
 ## Who This Is For
 

--- a/docs/method/manifesto/earned-escalation-vs-durable-execution.md
+++ b/docs/method/manifesto/earned-escalation-vs-durable-execution.md
@@ -1,0 +1,49 @@
+# Earned Escalation vs Durable Execution
+
+There are two philosophies for making workflows survive failure.
+
+**Durable execution** says: write your workflow as code, and the platform will replay event history to reconstruct state after crashes. The workflow survives because the runtime is persistent. The workflow is code. The durability is infrastructure.
+
+**Earned escalation** says: workflows advance only when they prove readiness. Each stage presents evidence. A deterministic gate verifies it. The workflow survives not by recovering from failure, but by refusing to advance on unverified output.
+
+These answer different questions.
+
+Durable execution asks: *Did the workflow complete?*
+
+Earned escalation asks: *Did the workflow earn completion?*
+
+## When Durable Execution Is the Right Choice
+
+Durable execution is the right model for workflows where the work itself is the only question. Payment processing. Order fulfillment. Microservice choreography. The output is deterministic — a charge either succeeds or it doesn't. The risk is failure to complete, not failure to verify.
+
+## When Earned Escalation Is the Right Choice
+
+Earned escalation is the right model when the output requires judgment to verify. When the agent doing the work can produce output that looks correct but isn't. When "the task is done" and "the task is done correctly" are different claims that require separate evidence.
+
+AI agents are exactly this kind of worker. An agent can produce output that passes superficial checks — tests green, linter clean — while introducing subtle regressions, security holes, or logic errors. Durability doesn't help here. The workflow completed. That's the problem.
+
+## Workflow-as-Data vs Workflow-as-Code
+
+Durable execution typically encodes workflows as deterministic code functions. The workflow definition is a source file.
+
+An alternative is workflow-as-data: the state machine definition lives in a database. Entities advance through states. Gates are shell commands or API calls, not inline code. This makes flows inspectable, mutable at runtime, and decoupled from deployment.
+
+The tradeoff: workflow-as-code is easier to version and test. Workflow-as-data is easier to evolve without redeployment and gives agents the ability to inspect and modify their own pipeline.
+
+## The Gate Is the Design
+
+In earned escalation, the gate is not a validation layer bolted on at the end. The gate is the central design decision. Every state transition must answer: what evidence is required, and how is it verified deterministically?
+
+- Not: does the output look correct to the agent?
+- Not: does the agent believe the output is correct?
+- Yes: does the shell command return exit code 0?
+
+The agent does work. The gate decides if the work is sufficient. These are separate concerns performed by separate systems.
+
+## Composability
+
+Earned escalation and durable execution are not mutually exclusive. A pipeline can use durable execution for stages where completion is the only concern, and earned escalation at boundaries where verification is required. The key is recognizing which question each stage is answering.
+
+---
+
+See [WOPR implementation](../../wopr/manifesto/earned-escalation-vs-durable-execution.md)

--- a/docs/wopr/manifesto/earned-escalation-vs-durable-execution.md
+++ b/docs/wopr/manifesto/earned-escalation-vs-durable-execution.md
@@ -1,10 +1,10 @@
-# Design Philosophy
+# Earned Escalation in the WOPR Stack
+
+See [method principle](../../method/manifesto/earned-escalation-vs-durable-execution.md)
 
 ## Why Not Temporal?
 
-You might be thinking: "This sounds like a workflow engine. Why not use Temporal?"
-
-Temporal is excellent. It's battle-tested, widely adopted, and built for durable execution of distributed systems. If you're orchestrating payment flows, order processing, or microservice choreography — use Temporal. Seriously.
+Temporal is excellent. It's battle-tested, widely adopted, and built for durable execution of distributed systems. If you're orchestrating payment flows, order processing, or microservice choreography — use Temporal.
 
 But Temporal's model is: write your workflow as deterministic code, and we'll replay event history to reconstruct state after failures. The workflow is code. The durability comes from the server. The platform runs as a cluster.
 
@@ -29,8 +29,8 @@ DEFCON is the escalation ladder. But a ladder needs someone to climb it and some
 **[NORAD](https://github.com/wopr-network/norad)** is the operations center. It watches the world for events, claims work from DEFCON, dispatches WOPR, and feeds signals back. It manages the floor — how many workers, what they're working on, routing results between the thing that does the work and the thing that decides if the work is good enough.
 
 ```text
-NORAD watches → event arrives → claims from DEFCON → dispatches WOPR
-WOPR works → emits signal → NORAD reports to DEFCON → gate checks → escalate or hold
+NORAD watches -> event arrives -> claims from DEFCON -> dispatches WOPR
+WOPR works -> emits signal -> NORAD reports to DEFCON -> gate checks -> escalate or hold
 ```
 
 WOPR doesn't know what DEFCON is. DEFCON doesn't know what WOPR is. NORAD connects them. Three systems, three roles, one metaphor that refuses to break down.


### PR DESCRIPTION
## Summary

- Rewrote the WarGames paragraph: WOPR didn't bypass DEFCON, it *played through it perfectly*. The problem was the game wasn't real.
- Added **"Why Not Temporal?"** section — contrasts durable execution ("did it complete?") with earned escalation ("did it *earn* completion?")
- Added **"The Full Stack"** section connecting WOPR, DEFCON, and NORAD with links and the narrative thread
- Threaded "We gave an AI the launch codes. On purpose." through the closer
- Added fourth bullet to "Who This Is For"

## Context

DEFCON + NORAD + WOPR is a WarGames metaphor that refuses to break down. This PR leans into it — shipping to production *is* dangerous, WOPR *should* have to earn every DEFCON level, and when it plays the game to perfection the launch is correct because the game is real.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All internal links resolve
- [ ] Narrative is consistent with NORAD README (companion PR)

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the README’s WarGames metaphor and introduce new sections that position DEFCON within a broader AI workflow stack and compare it to Temporal.

New Features:
- Add a "Why Not Temporal?" section explaining how DEFCON differs from Temporal and when to use each.
- Add a "The Full Stack" section describing how DEFCON works alongside WOPR and NORAD in the overall AI workflow stack.
- Extend the "Who This Is For" audience list with a new case for giving AI agents “launch codes” with enforced gating.

Enhancements:
- Rewrite the WarGames / DEFCON narrative in the README to emphasize earned escalation, real evidence, and the launch-codes framing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revise README WarGames narrative and add architecture manifestos to document earned escalation, Temporal comparison, and WOPR full‑stack roles in [README.md](https://github.com/wopr-network/defcon/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
> Updates the WarGames analogy and AI pipeline critique in [README.md](https://github.com/wopr-network/defcon/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), adds an Architecture & Design Philosophy section, and introduces two manifesto docs detailing earned escalation vs durable execution and WOPR stack roles with Temporal comparison.
>
> #### 📍Where to Start
> Start with the updated narrative and new links in [README.md](https://github.com/wopr-network/defcon/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), then review the method manifesto in [docs/method/manifesto/earned-escalation-vs-durable-execution.md](https://github.com/wopr-network/defcon/pull/55/files#diff-d2a5a407c91819849d31b73edcb6924ae0f20c55689977c8d5d7d50394515bd6) followed by the WOPR manifesto in [docs/wopr/manifesto/earned-escalation-vs-durable-execution.md](https://github.com/wopr-network/defcon/pull/55/files#diff-dd6a83152dae80116a6b2136c25b18c01552e6bdb75c558aa569d5c291c5ef88).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 20eb0b5. 43 files reviewed, 31 issues evaluated, 17 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/api/server.ts — 0 comments posted, 3 evaluated, 2 filtered</summary>
>
> - [line 48](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/api/server.ts#L48): The `readBody` function causes a deadlock when a request body exceeds `BODY_SIZE_LIMIT`. Calling `req.destroy()` inside the 'data' handler stops the stream immediately, so the 'end' event never fires. Additionally, `req.destroy()` does not emit an 'error' event by default. As a result, the Promise returned by `readBody` never settles (neither resolves nor rejects), causing the `await readBody(req)` in the request handler to hang indefinitely instead of returning the intended 413 response. <b>[ Posting failed ]</b>
> - [line 130](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/api/server.ts#L130): The `POST /api/entities` endpoint (lines 130-142) creates entities by calling `deps.engine.createEntity` directly without checking any authentication tokens. This bypasses the security model enforced by the `admin.entity.create` MCP tool (which checks `adminToken`) and other write endpoints (which check `workerToken`). This allows unauthorized users to trigger flows and create data. To fix this, the endpoint should either validate `adminToken` manually or delegate to `callToolHandler("admin.entity.create", ...)` which enforces the check. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/config/exporter.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 51](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/config/exporter.ts#L51): In `exportSeed`, the mapping logic for `seedStates` (lines 51–60) omits the `onEnter` property. This property was added to `State` and `StateDefinitionSchema` to support state-entry commands. By omitting it, the exporter strips entry configurations (commands, artifacts, timeouts) from the generated seed file. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/config/seed-loader.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 89](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/config/seed-loader.ts#L89): In `parseSeedAndLoad`, when creating a new flow (lines 89–100), the `affinityWindowMs` property is not passed to `flowRepo.create`. Although `affinityWindowMs` is present in the `SeedFileSchema` (parsed as `f`) and accepted by `CreateFlowInput`, it is ignored here, causing imported flows to revert to default values instead of using the configuration from the seed file. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>src/engine/engine.ts — 0 comments posted, 3 evaluated, 2 filtered</summary>
>
> - [line 225](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/engine/engine.ts#L225): In `Engine.processSignal`, if the `onEnter` hook fails (returns an error), the method returns early at line 225. This bypasses `executeSpawn` (line 292). Since the entity's state transition was already committed to the database in step 5 (line 173), the entity is left in the new state but missing the side-effects of the transition (the spawned child flow). Because the entity has already transitioned, there is no standard mechanism to retry the operation and trigger the missing spawn, leading to permanent state corruption for that process instance. <b>[ Out of scope ]</b>
> - [line 454](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/engine/engine.ts#L454): In `claimWork`, the code iterates over specific unclaimed invocations (`pending`) but attempts to claim an arbitrary entity in the matching stage using `entityRepo.claim(flowId, stage)`. This creates a race condition where the engine may claim an entity (e.g., Entity A) that does not match the invocation being processed (e.g., Invocation B for Entity B). <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/engine/gate-evaluator.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 48](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/engine/gate-evaluator.ts#L48): The command argument parsing uses naive whitespace splitting (`split(/\s+/)`), which incorrectly handles arguments containing spaces. With the introduction of Handlebars templating in this PR, injected values (e.g., `{{entity.description}}`) will frequently contain spaces. For example, a command `script.sh "{{entity.value}}"` where value is `A B` will be split into arguments `['"A', 'B"']` instead of a single argument `['A B']`. Since `execFile` does not execute a shell, these incorrect arguments are passed literally to the executable, likely causing command failures or logic errors. A proper shell-quote parsing library should be used to split `renderedCommand`. <b>[ Cross-file consolidated ]</b>
> - [line 157](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/engine/gate-evaluator.ts#L157): The use of `Promise.race` in `runFunction` creates a potential unhandled promise rejection that can crash the application. If `timeoutPromise` settles first (triggering a timeout), the promise returned by `Promise.resolve(fn(entity, gate))` remains pending. If the user-supplied function `fn` subsequently throws an error or rejects, that rejection will be unhandled because `Promise.race` has already returned and no catch handler is attached to the user's promise. In Node.js, unhandled rejections typically terminate the process, allowing a slow-then-failing gate to cause a Denial of Service. <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>src/engine/on-enter.ts — 0 comments posted, 3 evaluated, 3 filtered</summary>
>
> - [line 19](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/engine/on-enter.ts#L19): The idempotency check logic prevents commands with empty `artifacts` lists from ever running. `[].every(...)` returns `true` for an empty array, so if a user configures a command purely for side effects (e.g. `artifacts: []`), `allPresent` evaluates to `true`, and the function returns early with `skipped: true`. <b>[ Posting failed ]</b>
> - [line 28](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/engine/on-enter.ts#L28): Critical Command Injection vulnerability. The code interpolates `entity` data directly into a command string using Handlebars and then executes it via `/bin/sh -c`. Handlebars performs HTML escaping (e.g. `<`) but does not escape shell metacharacters (e.g. `;`, `$`, `|`, `(`, `)`). Malicious data within `entity` properties can execute arbitrary code on the server. <b>[ Posting failed ]</b>
> - [line 87](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/engine/on-enter.ts#L87): The code crashes if the executed command outputs `null` (which is valid JSON). `JSON.parse('null')` returns `null`. The subsequent access `parsed[key]` at line 87 attempts to read a property of `null`, throwing a `TypeError` and causing the Promise to reject unexpectedly instead of handling the invalid output gracefully. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/execution/active-runner.ts — 0 comments posted, 4 evaluated, 2 filtered</summary>
>
> - [line 118](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/execution/active-runner.ts#L118): The `ActiveRunner` fails to handle `onEnter` hook failures, leading to stuck entities. If `this.engine.processSignal` returns `onEnterFailed: true` (which occurs when an entity transitions but the `onEnter` hook errors), the engine returns early and skips creating a new invocation for the new state. The `ActiveRunner` does not check for `onEnterFailed` or take any recovery action. As a result, the entity successfully transitions to the new state but is left without an invocation, preventing any further processing. <b>[ Cross-file consolidated ]</b>
> - [line 131](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/execution/active-runner.ts#L131): The `ActiveRunner` retrieves `invocations` (plural) but then processes only the first one found inside the `pollOnce` loop due to an unconditional `return true` after `processInvocation`. This means that if `findUnclaimedActive` returns multiple candidates, only the first one is processed per poll cycle. While this is inefficient, the more critical issue is that `processInvocation` is awaited. If `processInvocation` takes a long time (e.g., AI latency), the `ActiveRunner` is blocked from picking up other work. However, looking closely at lines 78-83: <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/execution/mcp-server.ts — 0 comments posted, 3 evaluated, 1 filtered</summary>
>
> - [line 565](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/execution/mcp-server.ts#L565): The `handleFlowClaim` function uses a hardcoded `AFFINITY_WINDOW_MS` (1 hour) to determine worker affinity priority, completely ignoring the `affinityWindowMs` setting configured on the `Flow`. This causes two critical issues: <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/execution/tool-schemas.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 7](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/execution/tool-schemas.ts#L7): The schema now allows `worker_id` (snake_case) as an optional input, but the `handleFlowClaim` function (shown in usages) only destructures `workerId` (camelCase) from the validated data. Because `workerId` is also optional, no error is thrown if it is missing. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/repositories/drizzle/flow.repo.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 383](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/repositories/drizzle/flow.repo.ts#L383): In `restore`, the fields `affinityWindowMs`, `discipline`, and `timeoutPrompt` are accessed from `snap` and passed to the update query. When restoring a legacy snapshot (created before these fields existed), these properties will be `undefined`. Drizzle's `update(...).set(...)` ignores properties with `undefined` values, preserving the *current* values in the database instead of resetting them. This causes the restored flow to retain configuration from the newer version being overwritten (e.g., a modified `affinityWindowMs` or `discipline`), rather than reverting to the default or null state appropriate for the snapshot version. <b>[ Posting failed ]</b>
> </details>
>
> <details>
> <summary>src/repositories/drizzle/invocation.repo.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 163](https://github.com/wopr-network/defcon/blob/20eb0b5530991556675c19004f4c9ddf88d3e49c/src/repositories/drizzle/invocation.repo.ts#L163): `findUnclaimedByFlow` retrieves invocations without checking if the parent entity has an active affinity to a specific worker. This means any worker polling this endpoint (e.g. for "discipline-based claiming") will receive and potentially claim tasks that are effectively locked to another worker via `affinityWorkerId` and `affinityExpiresAt`. This bypasses the affinity mechanism, leading to race conditions where generic workers steal tasks intended for specific workers, causing context loss. The query should filter out rows where `entities.affinityWorkerId` is not null and `entities.affinityExpiresAt` is in the future. <b>[ Posting failed ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded narrative, new "Why Not Temporal?", "The Full Stack", and audience guidance; clarified escalation/gating model.

* **New Features**
  * New built-in release & incident pipelines and gate-driven workflow seeds.
  * HTTP API/server with worker/admin token auth and REST endpoints.
  * Worker affinity, prioritization, on-enter hooks, gate timeouts, and gate-driven progression.

* **Tests**
  * Added comprehensive API, on-enter, worker-affinity, and coverage tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->