### PR TITLE
ci: add dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,11 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-merge:
+    uses: wopr-network/.github/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit
+


### PR DESCRIPTION
Adds the org-wide dependabot auto-merge reusable workflow. Patch/minor dependabot PRs will be auto-approved and merged when CI passes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Dependabot auto-merge GitHub Actions workflow to run on pull_request opened, synchronize, and reopened events in [.github/workflows/dependabot-auto-merge.yml](https://github.com/wopr-network/defcon/pull/71/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1)
> Add a workflow that delegates to `wopr-network/.github/.github/workflows/dependabot-auto-merge.yml@main` with `secrets: inherit` and triggers on `pull_request` events: `opened`, `synchronize`, `reopened`.
>
> #### 📍Where to Start
> Start with the workflow definition in [.github/workflows/dependabot-auto-merge.yml](https://github.com/wopr-network/defcon/pull/71/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14e73fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->