### PR TITLE
test: add event.repo and transition-log.repo test suites (WOP-1923)

### DIFF
--- a/src/repositories/drizzle/event.repo.ts
+++ b/src/repositories/drizzle/event.repo.ts
@@ -22,4 +22,8 @@ export class DrizzleEventRepository implements IEventRepository {
       })
       .run();
   }
+
+  findAll(): (typeof events.$inferSelect)[] {
+    return this.db.select().from(events).all();
+  }
 }

--- a/tests/repositories/drizzle/event.repo.test.ts
+++ b/tests/repositories/drizzle/event.repo.test.ts
@@ -3,7 +3,6 @@ import type Database from "better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { bootstrap } from "../../../src/main.js";
 import { DrizzleEventRepository } from "../../../src/repositories/drizzle/event.repo.js";
-import { events } from "../../../src/repositories/drizzle/schema.js";
 
 let db: BetterSQLite3Database;
 let sqlite: Database.Database;
@@ -25,7 +24,7 @@ describe("DrizzleEventRepository", () => {
     it("inserts a definition.changed event with flowId", async () => {
       await repo.emitDefinitionChanged("flow-1", "flow.create", { name: "test-flow" });
 
-      const rows = db.select().from(events).all();
+      const rows = repo.findAll();
       expect(rows).toHaveLength(1);
       expect(rows[0].type).toBe("definition.changed");
       expect(rows[0].flowId).toBe("flow-1");
@@ -38,7 +37,7 @@ describe("DrizzleEventRepository", () => {
     it("inserts a definition.changed event with null flowId", async () => {
       await repo.emitDefinitionChanged(null, "gate.create", { gateName: "lint" });
 
-      const rows = db.select().from(events).all();
+      const rows = repo.findAll();
       expect(rows).toHaveLength(1);
       expect(rows[0].flowId).toBeNull();
       expect(rows[0].payload).toEqual({ tool: "gate.create", gateName: "lint" });
@@ -47,7 +46,7 @@ describe("DrizzleEventRepository", () => {
     it("coerces empty string flowId to null", async () => {
       await repo.emitDefinitionChanged("", "flow.update", {});
 
-      const rows = db.select().from(events).all();
+      const rows = repo.findAll();
       expect(rows).toHaveLength(1);
       expect(rows[0].flowId).toBeNull();
     });
@@ -57,7 +56,7 @@ describe("DrizzleEventRepository", () => {
       await repo.emitDefinitionChanged("flow-1", "state.add", { b: 2 });
       await repo.emitDefinitionChanged("flow-2", "flow.create", { c: 3 });
 
-      const rows = db.select().from(events).all();
+      const rows = repo.findAll();
       expect(rows).toHaveLength(3);
       const ids = rows.map((r) => r.id);
       expect(new Set(ids).size).toBe(3);
@@ -68,7 +67,7 @@ describe("DrizzleEventRepository", () => {
       await repo.emitDefinitionChanged("flow-1", "flow.create", {});
       const after = Date.now();
 
-      const rows = db.select().from(events).all();
+      const rows = repo.findAll();
       expect(rows[0].emittedAt).toBeGreaterThanOrEqual(before);
       expect(rows[0].emittedAt).toBeLessThanOrEqual(after);
     });
@@ -77,7 +76,7 @@ describe("DrizzleEventRepository", () => {
       const payload = { nested: { key: "value" }, arr: [1, 2, 3], flag: true };
       await repo.emitDefinitionChanged("flow-1", "flow.update", payload);
 
-      const rows = db.select().from(events).all();
+      const rows = repo.findAll();
       expect(rows[0].payload).toEqual({ tool: "flow.update", ...payload });
     });
   });

--- a/tests/repositories/drizzle/transition-log.repo.test.ts
+++ b/tests/repositories/drizzle/transition-log.repo.test.ts
@@ -3,11 +3,14 @@ import type Database from "better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { bootstrap } from "../../../src/main.js";
 import { DrizzleTransitionLogRepository } from "../../../src/repositories/drizzle/transition-log.repo.js";
-import { flowDefinitions, entities } from "../../../src/repositories/drizzle/schema.js";
+import { DrizzleFlowRepository } from "../../../src/repositories/drizzle/flow.repo.js";
+import { DrizzleEntityRepository } from "../../../src/repositories/drizzle/entity.repo.js";
 
 let db: BetterSQLite3Database;
 let sqlite: Database.Database;
 let repo: DrizzleTransitionLogRepository;
+let entityId1: string;
+let entityId2: string;
 
 beforeEach(async () => {
   const res = bootstrap(":memory:");
@@ -16,32 +19,13 @@ beforeEach(async () => {
   repo = new DrizzleTransitionLogRepository(db);
 
   // Seed flow + entities for FK constraints on entity_history
-  await db.insert(flowDefinitions).values({
-    id: "flow-1",
-    name: "test-flow",
-    initialState: "open",
-    version: 1,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  });
-  await db.insert(entities).values([
-    {
-      id: "entity-1",
-      flowId: "flow-1",
-      state: "open",
-      priority: 0,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    },
-    {
-      id: "entity-2",
-      flowId: "flow-1",
-      state: "open",
-      priority: 0,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    },
-  ]);
+  const flowRepo = new DrizzleFlowRepository(db);
+  const entityRepo = new DrizzleEntityRepository(db);
+  const flow = await flowRepo.create({ name: "test-flow", initialState: "open" });
+  const e1 = await entityRepo.create(flow.id, "open");
+  const e2 = await entityRepo.create(flow.id, "open");
+  entityId1 = e1.id;
+  entityId2 = e2.id;
 });
 
 afterEach(() => {
@@ -53,7 +37,7 @@ describe("DrizzleTransitionLogRepository", () => {
     it("records a transition and returns it with an id", async () => {
       const now = new Date();
       const result = await repo.record({
-        entityId: "entity-1",
+        entityId: entityId1,
         fromState: "open",
         toState: "in_progress",
         trigger: "claim",
@@ -62,7 +46,7 @@ describe("DrizzleTransitionLogRepository", () => {
       });
 
       expect(result.id).toBeTypeOf("string");
-      expect(result.entityId).toBe("entity-1");
+      expect(result.entityId).toBe(entityId1);
       expect(result.fromState).toBe("open");
       expect(result.toState).toBe("in_progress");
       expect(result.trigger).toBe("claim");
@@ -72,7 +56,7 @@ describe("DrizzleTransitionLogRepository", () => {
 
     it("records a transition with null fromState (initial transition)", async () => {
       const result = await repo.record({
-        entityId: "entity-1",
+        entityId: entityId1,
         fromState: null,
         toState: "open",
         trigger: null,
@@ -93,7 +77,7 @@ describe("DrizzleTransitionLogRepository", () => {
 
       // Insert out of order to verify sorting
       await repo.record({
-        entityId: "entity-1",
+        entityId: entityId1,
         fromState: "in_progress",
         toState: "done",
         trigger: "complete",
@@ -101,7 +85,7 @@ describe("DrizzleTransitionLogRepository", () => {
         timestamp: t3,
       });
       await repo.record({
-        entityId: "entity-1",
+        entityId: entityId1,
         fromState: null,
         toState: "open",
         trigger: null,
@@ -109,7 +93,7 @@ describe("DrizzleTransitionLogRepository", () => {
         timestamp: t1,
       });
       await repo.record({
-        entityId: "entity-1",
+        entityId: entityId1,
         fromState: "open",
         toState: "in_progress",
         trigger: "claim",
@@ -117,7 +101,7 @@ describe("DrizzleTransitionLogRepository", () => {
         timestamp: t2,
       });
 
-      const history = await repo.historyFor("entity-1");
+      const history = await repo.historyFor(entityId1);
 
       expect(history).toHaveLength(3);
       expect(history[0].toState).toBe("open");
@@ -132,7 +116,7 @@ describe("DrizzleTransitionLogRepository", () => {
     it("returns only history for the requested entity", async () => {
       const now = new Date();
       await repo.record({
-        entityId: "entity-1",
+        entityId: entityId1,
         fromState: null,
         toState: "open",
         trigger: null,
@@ -140,7 +124,7 @@ describe("DrizzleTransitionLogRepository", () => {
         timestamp: now,
       });
       await repo.record({
-        entityId: "entity-2",
+        entityId: entityId2,
         fromState: null,
         toState: "open",
         trigger: null,
@@ -148,13 +132,13 @@ describe("DrizzleTransitionLogRepository", () => {
         timestamp: now,
       });
 
-      const history1 = await repo.historyFor("entity-1");
-      const history2 = await repo.historyFor("entity-2");
+      const history1 = await repo.historyFor(entityId1);
+      const history2 = await repo.historyFor(entityId2);
 
       expect(history1).toHaveLength(1);
-      expect(history1[0].entityId).toBe("entity-1");
+      expect(history1[0].entityId).toBe(entityId1);
       expect(history2).toHaveLength(1);
-      expect(history2[0].entityId).toBe("entity-2");
+      expect(history2[0].entityId).toBe(entityId2);
     });
 
     it("returns empty array for unknown entity", async () => {
@@ -166,7 +150,7 @@ describe("DrizzleTransitionLogRepository", () => {
       const base = Date.now();
       for (let i = 0; i < 5; i++) {
         await repo.record({
-          entityId: "entity-1",
+          entityId: entityId1,
           fromState: `state-${i}`,
           toState: `state-${i + 1}`,
           trigger: `trigger-${i}`,
@@ -175,7 +159,7 @@ describe("DrizzleTransitionLogRepository", () => {
         });
       }
 
-      const history = await repo.historyFor("entity-1");
+      const history = await repo.historyFor(entityId1);
       expect(history).toHaveLength(5);
       const ids = history.map((h) => h.id);
       expect(new Set(ids).size).toBe(5);
@@ -187,7 +171,7 @@ describe("DrizzleTransitionLogRepository", () => {
     it("round-trips timestamp through epoch storage", async () => {
       const ts = new Date("2026-03-07T12:34:56.000Z");
       await repo.record({
-        entityId: "entity-1",
+        entityId: entityId1,
         fromState: "a",
         toState: "b",
         trigger: "go",
@@ -195,7 +179,7 @@ describe("DrizzleTransitionLogRepository", () => {
         timestamp: ts,
       });
 
-      const history = await repo.historyFor("entity-1");
+      const history = await repo.historyFor(entityId1);
       expect(history[0].timestamp.getTime()).toBe(ts.getTime());
     });
   });


### PR DESCRIPTION
## Summary
Closes WOP-1923

- Add `tests/repositories/drizzle/event.repo.test.ts` with 6 tests covering `DrizzleEventRepository.emitDefinitionChanged`
- Add `tests/repositories/drizzle/transition-log.repo.test.ts` with 7 tests covering `DrizzleTransitionLogRepository.record` and `historyFor`
- Both suites use `bootstrap(":memory:")` with Drizzle migrations for consistent in-memory SQLite setup

## Test plan
- [ ] `npm run check` passes (biome + tsc)
- [ ] `npx vitest run tests/repositories/drizzle/event.repo.test.ts tests/repositories/drizzle/transition-log.repo.test.ts` — 13 tests pass

Generated with Claude Code

## Summary by Sourcery

Add repository-level tests for Drizzle event and transition-log persistence using an in-memory SQLite setup.

Tests:
- Add tests for DrizzleEventRepository.emitDefinitionChanged covering flowId handling, payload shaping, id uniqueness, and emittedAt timestamps.
- Add tests for DrizzleTransitionLogRepository.record and historyFor covering initial and subsequent transitions, ordering, entity scoping, id uniqueness, and timestamp round-tripping.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `DrizzleEventRepository.findAll()` and introduce test suites validating `DrizzleEventRepository.emitDefinitionChanged` and `DrizzleTransitionLogRepository` per WOP-1923
> Introduce a `findAll()` query on events and add targeted tests for event emission and transition logging, covering IDs, nullables, payloads, ordering, and timestamp round-trips. Key files: [event.repo.ts](https://github.com/wopr-network/defcon/pull/74/files#diff-2e40ab58d52c32b43f83cec4169ca433e1833b75e0ed7f8e88d737c7e0cb3623), [event.repo.test.ts](https://github.com/wopr-network/defcon/pull/74/files#diff-634a3ea8f05e0ed875c5b1d2766f8b6830e728d04cf7b5f2ad2c13ff29e57744), [transition-log.repo.test.ts](https://github.com/wopr-network/defcon/pull/74/files#diff-e16ccd2ac93365993639f6d033417a176536c424ad7f3ed76c82cb5c7d58192b).
>
> #### 🖇️ Linked Issues
> This pull request addresses testing coverage for [WOP-1923](ticket:jira/WOP-1923).
>
> #### 📍Where to Start
> Start with the repository changes in `DrizzleEventRepository` at [event.repo.ts](https://github.com/wopr-network/defcon/pull/74/files#diff-2e40ab58d52c32b43f83cec4169ca433e1833b75e0ed7f8e88d737c7e0cb3623), then review tests beginning at [event.repo.test.ts](https://github.com/wopr-network/defcon/pull/74/files#diff-634a3ea8f05e0ed875c5b1d2766f8b6830e728d04cf7b5f2ad2c13ff29e57744).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75d6556.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for event definition notifications and transition history tracking to enhance system reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->