### PR TITLE
docs: update CLAUDE.md gotchas from WOP-1897 fixer findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,3 +30,8 @@ Key concepts that must appear in both method/ and wopr/ docs:
 - Use ASCII diagrams, not images. The audience includes AI agents that can't see images.
 - When referencing a method/ principle from wopr/, use relative links: `[event bus pattern](../../method/pipeline/triggers/event-bus.md)`.
 - When referencing a wopr/ implementation from method/, use: `See [WOPR implementation](../../wopr/...)`.
+
+## Gotchas
+
+- **Naming**: REST API and `FlowClaimSchema` use `worker_id` (snake_case), never `workerId` (camelCase) — all docs and code must match.
+- **CORS**: `isLoopbackOrigin()` regex must use `https?://` prefix (not just `http://`) to cover both HTTP and SSE/HTTPS transports.


### PR DESCRIPTION
Adds 2 gotchas learned from WOP-1897 fixer cycles:
- worker_id snake_case convention (REST API + FlowClaimSchema)
- CORS isLoopbackOrigin() regex must use https?:// prefix for HTTP+SSE

Skipped 1:1 doc rule (already documented).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Document naming and CORS-related gotchas discovered during recent fixer cycles in CLAUDE.md.

Documentation:
- Add documentation about the snake_case worker_id naming convention across REST API and FlowClaimSchema.
- Document the requirement for using an https?:// prefix in the isLoopbackOrigin() CORS regex to support both HTTP and HTTPS/SSE transports.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a Gotchas section to `CLAUDE.md` documenting `worker_id` naming for REST API and `FlowClaimSchema` and the `https?://` prefix requirement in `isLoopbackOrigin()` regex
> Add a Gotchas section to [CLAUDE.md](https://github.com/wopr-network/defcon/pull/86/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) covering `worker_id` snake_case requirements and CORS regex prefix `https?://` for `isLoopbackOrigin()`.
>
> #### 📍Where to Start
> Start with the new Gotchas section in [CLAUDE.md](https://github.com/wopr-network/defcon/pull/86/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c569046.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->