### PR TITLE
refactor(engine): extract tryClaimInvocation from claimWork

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -392,162 +392,125 @@ export class Engine {
     }
 
     for (const flow of flows) {
-      const affinityWindow = flow.affinityWindowMs ?? 300000;
-
       // Try affinity match first if workerId provided
       if (workerId) {
         const affinityUnclaimed = await this.invocationRepo.findUnclaimedWithAffinity(flow.id, role, workerId);
         for (const pending of affinityUnclaimed) {
           const claimed = await this.entityRepo.claimById(pending.entityId, `agent:${role}`);
-          if (claimed) {
-            const claimedInvocation = await this.invocationRepo.claim(pending.id, `agent:${role}`);
-            if (!claimedInvocation) {
-              try {
-                await this.entityRepo.release(claimed.id, `agent:${role}`);
-              } catch (err) {
-                console.error(`release() failed for entity ${claimed.id}:`, err);
-              }
-              continue;
-            }
-
-            try {
-              await this.entityRepo.setAffinity(claimed.id, workerId, role, new Date(Date.now() + affinityWindow));
-            } catch (err) {
-              console.warn(`setAffinity failed for entity ${claimed.id} worker ${workerId} — continuing:`, err);
-            }
-
-            const state = flow.states.find((s) => s.name === pending.stage);
-            let build: { prompt: string; context: Record<string, unknown> | null };
-            if (state) {
-              const [invocations, gateResults] = await Promise.all([
-                this.invocationRepo.findByEntity(claimed.id),
-                this.gateRepo.resultsFor(claimed.id),
-              ]);
-              const enriched: EnrichedEntity = { ...claimed, invocations, gateResults };
-              build = await buildInvocation(state, enriched, this.adapters, flow);
-            } else {
-              build = { prompt: pending.prompt, context: null };
-            }
-
-            await this.eventEmitter.emit({
-              type: "entity.claimed",
-              entityId: claimed.id,
-              flowId: flow.id,
-              agentId: `agent:${role}`,
-              emittedAt: new Date(),
-            });
-            return {
-              entityId: claimed.id,
-              invocationId: claimedInvocation.id,
-              prompt: build.prompt,
-              context: build.context,
-            };
-          }
+          if (!claimed) continue;
+          const result = await this.tryClaimInvocation(pending, claimed, flow, role, workerId);
+          if (result) return result;
         }
       }
 
       // Prefer claiming an existing unclaimed invocation created by processSignal
       // to avoid creating a duplicate. Fall back to creating a new one if none exist.
       const unclaimed = await this.invocationRepo.findUnclaimedByFlow(flow.id);
-
       for (const pending of unclaimed) {
         const claimed = await this.entityRepo.claim(flow.id, pending.stage, `agent:${role}`);
-        if (claimed) {
-          const claimedInvocation = await this.invocationRepo.claim(pending.id, `agent:${role}`);
-          if (!claimedInvocation) {
-            try {
-              await this.entityRepo.release(claimed.id, `agent:${role}`);
-            } catch (err) {
-              console.error(`release() failed for entity ${claimed.id}:`, err);
-            }
-            continue;
-          }
-
-          if (workerId) {
-            try {
-              await this.entityRepo.setAffinity(claimed.id, workerId, role, new Date(Date.now() + affinityWindow));
-            } catch (err) {
-              console.warn(`setAffinity failed for entity ${claimed.id} worker ${workerId} — continuing:`, err);
-            }
-          }
-
-          const state = flow.states.find((s) => s.name === pending.stage);
-          let build: { prompt: string; context: Record<string, unknown> | null };
-          if (state) {
-            const [invocations, gateResults] = await Promise.all([
-              this.invocationRepo.findByEntity(claimed.id),
-              this.gateRepo.resultsFor(claimed.id),
-            ]);
-            const enriched: EnrichedEntity = { ...claimed, invocations, gateResults };
-            build = await buildInvocation(state, enriched, this.adapters, flow);
-          } else {
-            build = { prompt: pending.prompt, context: null };
-          }
-
-          await this.eventEmitter.emit({
-            type: "entity.claimed",
-            entityId: claimed.id,
-            flowId: flow.id,
-            agentId: `agent:${role}`,
-            emittedAt: new Date(),
-          });
-          return {
-            entityId: claimed.id,
-            invocationId: claimedInvocation.id,
-            prompt: build.prompt,
-            context: build.context,
-          };
-        }
+        if (!claimed) continue;
+        const result = await this.tryClaimInvocation(pending, claimed, flow, role, workerId);
+        if (result) return result;
       }
 
       // No pre-existing unclaimed invocations — claim entity directly and create invocation
-      // Discipline filtering already happened at the flow level; any state with a prompt template is claimable
       const claimableStates = flow.states.filter((s) => !!s.promptTemplate);
       for (const state of claimableStates) {
         const claimed = await this.entityRepo.claim(flow.id, state.name, `agent:${role}`);
-        if (claimed) {
-          if (workerId) {
-            try {
-              await this.entityRepo.setAffinity(claimed.id, workerId, role, new Date(Date.now() + affinityWindow));
-            } catch (err) {
-              console.warn(`setAffinity failed for entity ${claimed.id} worker ${workerId} — continuing:`, err);
-            }
-          }
+        if (!claimed) continue;
 
-          const [invocations, gateResults] = await Promise.all([
-            this.invocationRepo.findByEntity(claimed.id),
-            this.gateRepo.resultsFor(claimed.id),
-          ]);
-          const enriched: EnrichedEntity = { ...claimed, invocations, gateResults };
-          const build = await buildInvocation(state, enriched, this.adapters, flow);
-          const invocation = await this.invocationRepo.create(
-            claimed.id,
-            state.name,
-            build.prompt,
-            build.mode,
-            undefined,
-            build.systemPrompt || build.userContent
-              ? { systemPrompt: build.systemPrompt, userContent: build.userContent }
-              : undefined,
-          );
-          await this.eventEmitter.emit({
-            type: "entity.claimed",
-            entityId: claimed.id,
-            flowId: flow.id,
-            agentId: `agent:${role}`,
-            emittedAt: new Date(),
-          });
-          return {
-            entityId: claimed.id,
-            invocationId: invocation.id,
-            prompt: build.prompt,
-            context: build.context,
-          };
-        }
+        await this.setAffinityIfNeeded(claimed.id, flow, role, workerId);
+        const build = await this.buildPrompt(state, claimed, flow);
+        const invocation = await this.invocationRepo.create(
+          claimed.id,
+          state.name,
+          build.prompt,
+          build.mode,
+          undefined,
+          build.systemPrompt || build.userContent
+            ? { systemPrompt: build.systemPrompt, userContent: build.userContent }
+            : undefined,
+        );
+        return this.emitAndReturn(claimed, invocation.id, build, flow, role);
       }
     }
 
     return null;
+  }
+
+  /**
+   * Try to claim an existing unclaimed invocation for an already-claimed entity.
+   * Handles the race condition where another worker claims the invocation first
+   * (releases the entity claim and returns null so the caller can try the next candidate).
+   */
+  private async tryClaimInvocation(
+    pending: { id: string; entityId: string; stage: string; prompt: string },
+    claimed: Entity,
+    flow: Flow,
+    role: string,
+    workerId?: string,
+  ): Promise<ClaimWorkResult | null> {
+    const claimedInvocation = await this.invocationRepo.claim(pending.id, `agent:${role}`);
+    if (!claimedInvocation) {
+      try {
+        await this.entityRepo.release(claimed.id, `agent:${role}`);
+      } catch (err) {
+        console.error(`release() failed for entity ${claimed.id}:`, err);
+      }
+      return null;
+    }
+
+    await this.setAffinityIfNeeded(claimed.id, flow, role, workerId);
+
+    const state = flow.states.find((s) => s.name === pending.stage);
+    const build = state ? await this.buildPrompt(state, claimed, flow) : { prompt: pending.prompt, context: null };
+
+    return this.emitAndReturn(claimed, claimedInvocation.id, build, flow, role);
+  }
+
+  private async setAffinityIfNeeded(entityId: string, flow: Flow, role: string, workerId?: string): Promise<void> {
+    if (!workerId) return;
+    const affinityWindow = flow.affinityWindowMs ?? 300000;
+    try {
+      await this.entityRepo.setAffinity(entityId, workerId, role, new Date(Date.now() + affinityWindow));
+    } catch (err) {
+      console.warn(`setAffinity failed for entity ${entityId} worker ${workerId} — continuing:`, err);
+    }
+  }
+
+  private async buildPrompt(
+    state: Flow["states"][number],
+    entity: Entity,
+    flow: Flow,
+  ): Promise<Awaited<ReturnType<typeof buildInvocation>>> {
+    const [invocations, gateResults] = await Promise.all([
+      this.invocationRepo.findByEntity(entity.id),
+      this.gateRepo.resultsFor(entity.id),
+    ]);
+    const enriched: EnrichedEntity = { ...entity, invocations, gateResults };
+    return buildInvocation(state, enriched, this.adapters, flow);
+  }
+
+  private async emitAndReturn(
+    entity: Entity,
+    invocationId: string,
+    build: { prompt: string; context: Record<string, unknown> | null },
+    flow: Flow,
+    role: string,
+  ): Promise<ClaimWorkResult> {
+    await this.eventEmitter.emit({
+      type: "entity.claimed",
+      entityId: entity.id,
+      flowId: flow.id,
+      agentId: `agent:${role}`,
+      emittedAt: new Date(),
+    });
+    return {
+      entityId: entity.id,
+      invocationId,
+      prompt: build.prompt,
+      context: build.context,
+    };
   }
 
   async getStatus(): Promise<EngineStatus> {


### PR DESCRIPTION
## Summary
- Extract shared claim-with-rollback pattern from `claimWork`'s three strategies into `tryClaimInvocation`
- Extract `setAffinityIfNeeded`, `buildPrompt`, `emitAndReturn` helpers
- Net -37 lines, zero behavior change

## Test plan
- [ ] All engine unit tests pass (206/206)
- [ ] Integration tests pass (CI has native bindings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Refactor engine work-claiming logic to centralize shared invocation-claim behavior while preserving existing behavior.

Enhancements:
- Extract a shared tryClaimInvocation helper to handle claiming existing invocations with rollback on failure.
- Introduce setAffinityIfNeeded to encapsulate worker affinity handling for claimed entities.
- Extract buildPrompt to centralize prompt/context construction for a claimed entity and state.
- Extract emitAndReturn to standardize emitting entity.claimed events and returning ClaimWorkResult objects.
- Simplify claimWork by delegating repeated claim/affinity/prompt/emission logic to the new helpers.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract `engine.Engine.tryClaimInvocation` and route claim/build/emit flow from `engine.Engine.processSignal` in [engine.ts](https://github.com/wopr-network/defcon/pull/90/files#diff-4cbf43f37f351f7f4cd5559150b9abeddc2ecfec94280eb6080e03a575e75f6d)
> Refactors `engine.Engine.processSignal` to delegate claim, affinity, prompt build, and emit steps to `engine.Engine.tryClaimInvocation`, `engine.Engine.setAffinityIfNeeded` (default window 300000 ms), `engine.Engine.buildPrompt`, and `engine.Engine.emitAndReturn` in [engine.ts](https://github.com/wopr-network/defcon/pull/90/files#diff-4cbf43f37f351f7f4cd5559150b9abeddc2ecfec94280eb6080e03a575e75f6d).
>
> #### 📍Where to Start
> Start with `engine.Engine.processSignal` in [engine.ts](https://github.com/wopr-network/defcon/pull/90/files#diff-4cbf43f37f351f7f4cd5559150b9abeddc2ecfec94280eb6080e03a575e75f6d), then review `engine.Engine.tryClaimInvocation` and its helper methods.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d38b456. 1 file reviewed, 3 issues evaluated, 2 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/engine/engine.ts — 1 comment posted, 3 evaluated, 2 filtered</summary>
>
> - [line 410](https://github.com/wopr-network/defcon/blob/d38b456cfdcaabfe8f593316530eb2db7e226b4f/src/engine/engine.ts#L410): Critical data mismatch in `claimWork` loop. When iterating through specific unclaimed invocations (`pending`), the code attempts to claim a corresponding entity using the generic `this.entityRepo.claim(flow.id, pending.stage, ...)` method instead of targeting the specific entity associated with the invocation. <b>[ Out of scope ]</b>
> - [line 410](https://github.com/wopr-network/defcon/blob/d38b456cfdcaabfe8f593316530eb2db7e226b4f/src/engine/engine.ts#L410): In `claimWork`, the loop iterating over `unclaimed` invocations attempts to claim a corresponding entity using `this.entityRepo.claim(flow.id, pending.stage, ...)`. This method claims *any* available entity in the given flow and state, not necessarily the one associated with the `pending` invocation. This causes a critical mismatch where the worker locks Invocation A (belonging to Entity A) but receives the data/context for Entity B. When the worker submits the result, it is applied to Entity A, corrupting its state with data derived from Entity B. Additionally, this allows a worker to modify an invocation for Entity A even if Entity A is currently locked by another process (since `claim` would just skip A and return B). Use `this.entityRepo.claimById(pending.entityId, ...)` instead. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->