### PR TITLE
test: raise cli.ts coverage to 50% with pure-function unit tests (WOP-1931)

### DIFF
--- a/src/execution/cli.ts
+++ b/src/execution/cli.ts
@@ -519,7 +519,7 @@ export function verifySessionToken(storedTokenHash: string | undefined, incoming
   return timingSafeEqual(storedBuf, incomingBuf);
 }
 
-function extractBearerToken(header: string | undefined): string | undefined {
+export function extractBearerToken(header: string | undefined): string | undefined {
   if (!header) return undefined;
   const lower = header.toLowerCase();
   if (!lower.startsWith("bearer ")) return undefined;

--- a/tests/execution/cli.test.ts
+++ b/tests/execution/cli.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 function hashToken(token: string): string {
   return createHash("sha256").update(token).digest("hex");
 }
-import { resolveSessionId, verifySessionToken } from "../../src/execution/cli.js";
+import { resolveSessionId, verifySessionToken, extractBearerToken, validateAdminToken, validateWorkerToken } from "../../src/execution/cli.js";
 
 const CLI = join(import.meta.dirname, "../../src/execution/cli.ts");
 
@@ -246,6 +246,116 @@ describe("verifySessionToken", () => {
   });
 });
 
+describe("extractBearerToken", () => {
+  it("extracts token from valid Bearer header", () => {
+    expect(extractBearerToken("Bearer my-secret-token")).toBe("my-secret-token");
+  });
+
+  it("is case-insensitive for Bearer prefix", () => {
+    expect(extractBearerToken("bearer my-token")).toBe("my-token");
+    expect(extractBearerToken("BEARER my-token")).toBe("my-token");
+  });
+
+  it("trims whitespace from extracted token", () => {
+    expect(extractBearerToken("Bearer   spaced-token  ")).toBe("spaced-token");
+  });
+
+  it("returns undefined for missing header", () => {
+    expect(extractBearerToken(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for non-Bearer header", () => {
+    expect(extractBearerToken("Basic dXNlcjpwYXNz")).toBeUndefined();
+  });
+
+  it("returns undefined for Bearer with no token", () => {
+    expect(extractBearerToken("Bearer ")).toBeUndefined();
+    expect(extractBearerToken("Bearer")).toBeUndefined();
+  });
+});
+
+describe("validateAdminToken", () => {
+  it("throws when HTTP is active and no admin token", () => {
+    expect(() =>
+      validateAdminToken({ adminToken: undefined, startHttp: true, transport: "stdio" }),
+    ).toThrow("DEFCON_ADMIN_TOKEN must be set");
+  });
+
+  it("throws when SSE transport and no admin token", () => {
+    expect(() =>
+      validateAdminToken({ adminToken: undefined, startHttp: false, transport: "sse" }),
+    ).toThrow("DEFCON_ADMIN_TOKEN must be set");
+  });
+
+  it("throws when token is whitespace-only with HTTP active", () => {
+    expect(() =>
+      validateAdminToken({ adminToken: "   ", startHttp: true, transport: "stdio" }),
+    ).toThrow("DEFCON_ADMIN_TOKEN must be set");
+  });
+
+  it("does not throw for stdio-only without token", () => {
+    expect(() =>
+      validateAdminToken({ adminToken: undefined, startHttp: false, transport: "stdio" }),
+    ).not.toThrow();
+  });
+
+  it("does not throw when token is provided with HTTP", () => {
+    expect(() =>
+      validateAdminToken({ adminToken: "real-token", startHttp: true, transport: "stdio" }),
+    ).not.toThrow();
+  });
+
+  it("does not throw when token is provided with SSE", () => {
+    expect(() =>
+      validateAdminToken({ adminToken: "real-token", startHttp: false, transport: "sse" }),
+    ).not.toThrow();
+  });
+
+  it("handles transport with mixed case and whitespace", () => {
+    expect(() =>
+      validateAdminToken({ adminToken: undefined, startHttp: false, transport: "  SSE  " }),
+    ).toThrow("DEFCON_ADMIN_TOKEN must be set");
+  });
+});
+
+describe("validateWorkerToken", () => {
+  it("throws when HTTP is active and no worker token", () => {
+    expect(() =>
+      validateWorkerToken({ workerToken: undefined, startHttp: true, transport: "stdio" }),
+    ).toThrow("DEFCON_WORKER_TOKEN must be set");
+  });
+
+  it("throws when SSE transport and no worker token", () => {
+    expect(() =>
+      validateWorkerToken({ workerToken: undefined, startHttp: false, transport: "sse" }),
+    ).toThrow("DEFCON_WORKER_TOKEN must be set");
+  });
+
+  it("throws when token is whitespace-only with HTTP active", () => {
+    expect(() =>
+      validateWorkerToken({ workerToken: "   ", startHttp: true, transport: "stdio" }),
+    ).toThrow("DEFCON_WORKER_TOKEN must be set");
+  });
+
+  it("does not throw for stdio-only without token", () => {
+    expect(() =>
+      validateWorkerToken({ workerToken: undefined, startHttp: false, transport: "stdio" }),
+    ).not.toThrow();
+  });
+
+  it("does not throw when token is provided with HTTP", () => {
+    expect(() =>
+      validateWorkerToken({ workerToken: "real-token", startHttp: true, transport: "stdio" }),
+    ).not.toThrow();
+  });
+
+  it("handles transport with mixed case and whitespace", () => {
+    expect(() =>
+      validateWorkerToken({ workerToken: undefined, startHttp: false, transport: "  SSE  " }),
+    ).toThrow("DEFCON_WORKER_TOKEN must be set");
+  });
+});
+
 describe("CLI validation", () => {
   it("serve rejects non-numeric --reaper-interval", () => {
     const dbPath = join(tmpdir(), `cli-serve-nan-${Date.now()}.db`);
@@ -258,6 +368,27 @@ describe("CLI validation", () => {
     const dbPath = join(tmpdir(), `cli-serve-low-${Date.now()}.db`);
     const output = runExpectFail(["serve", "--reaper-interval", "500"], { AGENTIC_DB_PATH: dbPath });
     expect(output).toMatch(/reaper-interval/i);
+    if (existsSync(dbPath)) rmSync(dbPath);
+  });
+
+  it("serve rejects non-numeric --claim-ttl", () => {
+    const dbPath = join(tmpdir(), `cli-serve-ttl-nan-${Date.now()}.db`);
+    const output = runExpectFail(["serve", "--claim-ttl", "abc"], { AGENTIC_DB_PATH: dbPath });
+    expect(output).toMatch(/claim-ttl/i);
+    if (existsSync(dbPath)) rmSync(dbPath);
+  });
+
+  it("serve rejects --claim-ttl below 5000", () => {
+    const dbPath = join(tmpdir(), `cli-serve-ttl-low-${Date.now()}.db`);
+    const output = runExpectFail(["serve", "--claim-ttl", "1000"], { AGENTIC_DB_PATH: dbPath });
+    expect(output).toMatch(/claim-ttl/i);
+    if (existsSync(dbPath)) rmSync(dbPath);
+  });
+
+  it("serve rejects --http-only and --mcp-only together", () => {
+    const dbPath = join(tmpdir(), `cli-serve-both-${Date.now()}.db`);
+    const output = runExpectFail(["serve", "--http-only", "--mcp-only"], { AGENTIC_DB_PATH: dbPath });
+    expect(output).toMatch(/http-only.*mcp-only|Cannot use/i);
     if (existsSync(dbPath)) rmSync(dbPath);
   });
 


### PR DESCRIPTION
## Summary
Closes WOP-1931

- Export `extractBearerToken` from `src/execution/cli.ts` to enable unit testing
- Add 19 new pure-function unit tests for `extractBearerToken`, `validateAdminToken`, and `validateWorkerToken`
- Add 3 subprocess-based validation tests for `--claim-ttl` and `--http-only`/`--mcp-only` mutual exclusion

## Test plan
- [ ] `npm run check` passes (biome + tsc)
- [ ] `npx vitest run tests/execution/cli.test.ts` passes (42 tests total)

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Increase test coverage for the CLI execution module, particularly around token handling and serve command validation.

Enhancements:
- Export extractBearerToken from the CLI execution module to make it directly testable.

Tests:
- Add unit tests for extractBearerToken, validateAdminToken, and validateWorkerToken pure functions.
- Add CLI validation tests for claim-ttl argument constraints and mutual exclusion of http-only and mcp-only flags.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `src/execution/cli.ts` unit test coverage to 50% and export `execution.extractBearerToken` for direct testing
> Add exports and pure-function tests for `execution.extractBearerToken`, `execution.validateAdminToken`, and `execution.validateWorkerToken`, plus CLI flag validation for `--claim-ttl`, `--http-only`, and `--mcp-only`. See [cli.ts](https://github.com/wopr-network/defcon/pull/93/files#diff-a54dc2dfdaac200897cd261ef0ca9686b3c7c4c9491a783fe94dbdcd4d0f7072) and [cli.test.ts](https://github.com/wopr-network/defcon/pull/93/files#diff-9c1393e381ab653cfbb9c577c3f0754917ac5c190beacaf7646bfd85c5b1f6e8).
>
> #### 🖇️ Linked Issues
> Addresses [WOP-1931](ticket:jira/WOP-1931) by increasing `cli.ts` test coverage to 50% with targeted unit tests.
>
> #### 📍Where to Start
> Start with token validation logic in `execution.validateAdminToken` and `execution.validateWorkerToken`, then review `execution.extractBearerToken` in [cli.ts](https://github.com/wopr-network/defcon/pull/93/files#diff-a54dc2dfdaac200897cd261ef0ca9686b3c7c4c9491a783fe94dbdcd4d0f7072) and corresponding cases in [cli.test.ts](https://github.com/wopr-network/defcon/pull/93/files#diff-9c1393e381ab653cfbb9c577c3f0754917ac5c190beacaf7646bfd85c5b1f6e8).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 048e137.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->