### PR TITLE
fix: seed-loader JSON.parse gives friendly error on malformed files (WOP-1927)

### DIFF
--- a/src/config/seed-loader.ts
+++ b/src/config/seed-loader.ts
@@ -29,17 +29,7 @@ export async function loadSeed(
     throw new Error(`Seed path escapes allowed root: ${resolvedSeed} is not under ${resolvedRoot}`);
   }
 
-  let realSeed: string;
-  try {
-    realSeed = realpathSync(resolvedSeed);
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      // File doesn't exist — let readFileSync throw its normal ENOENT error
-      const raw = readFileSync(resolvedSeed, "utf-8");
-      return parseSeedAndLoad(parseJson(raw, resolvedSeed), flowRepo, gateRepo, sqlite);
-    }
-    throw err;
-  }
+  const realSeed = realpathSync(resolvedSeed);
 
   let realRoot: string;
   try {
@@ -62,7 +52,7 @@ function parseJson(raw: string, path: string): unknown {
     return JSON.parse(raw);
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    throw new Error(`Invalid JSON in seed file: ${path}: ${msg}`);
+    throw new Error(`Invalid JSON in seed file: ${path}: ${msg}`, { cause: e });
   }
 }
 

--- a/tests/config/seed-loader.test.ts
+++ b/tests/config/seed-loader.test.ts
@@ -197,6 +197,26 @@ describe("loadSeed", () => {
     sqlite.close();
   });
 
+  it("preserves SyntaxError cause on malformed JSON", async () => {
+    const { sqlite, flowRepo, gateRepo } = setupDb();
+    const dir = join(tmpRoot, `seed-cause-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const seedPath = join(dir, "bad.json");
+    writeFileSync(seedPath, "{ not valid json !!");
+
+    let thrown: unknown;
+    try {
+      await loadSeed(seedPath, flowRepo, gateRepo, sqlite, { allowedRoot: tmpRoot });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error & { cause?: unknown }).cause).toBeInstanceOf(SyntaxError);
+
+    sqlite.close();
+  });
+
   it("accepts a seed path within the allowed root", async () => {
     const { sqlite, flowRepo, gateRepo } = setupDb();
     const seedPath = writeSeedFile(validSeed);


### PR DESCRIPTION
## Summary
Closes WOP-1927

- Added `parseJson` helper in `src/config/seed-loader.ts` that wraps `JSON.parse` in a try/catch
- Both call sites in `loadSeed` (normal path and ENOENT fallback) now use `parseJson`, passing the file path for context
- `parseSeedAndLoad` signature changed from `raw: string` to `json: unknown` — JSON parsing is now the caller's responsibility
- Added test that writes a file with invalid JSON and asserts the error message matches `/Invalid JSON in seed file/`

## Test plan
- [ ] `npm run check` passes (biome + tsc)
- [ ] `npx vitest run tests/config/seed-loader.test.ts` passes (11 tests including new malformed-JSON test)

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Improve seed loading to surface clearer errors for malformed JSON seed files and shift JSON parsing responsibility out of the core seed loading routine.

Bug Fixes:
- Ensure malformed seed JSON files produce a descriptive error that includes the file path instead of a generic JSON.parse failure.

Enhancements:
- Introduce a reusable JSON parsing helper for seed files that wraps JSON.parse with contextual error messages and adjust the seed parsing function to accept pre-parsed JSON.

Tests:
- Add a test verifying that loading a seed file with invalid JSON rejects with the new friendly error message.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `src/config/seed-loader.ts` surface path-aware JSON.parse errors for malformed seed files to provide a friendly message (WOP-1927)
> Add `parseJson` to wrap `JSON.parse` with a path-aware error; update `loadSeed` to resolve via `realpathSync` and pass parsed JSON to `parseSeedAndLoad`; adjust `parseSeedAndLoad` to accept pre-parsed JSON; add tests asserting the friendly error and preserved `SyntaxError` cause in [seed-loader.test.ts](https://github.com/wopr-network/defcon/pull/96/files#diff-bfc1b001a5548cf7c577881162516d5019d1466159cd012ffa5228cc4a14c60c).
>
> #### 📍Where to Start
> Start with `loadSeed` and the new `parseJson` helper in [seed-loader.ts](https://github.com/wopr-network/defcon/pull/96/files#diff-6e38b4695dbc06ece744bacff13cfb121a458ddafad26836eff53b57eb282772), then review the updated `parseSeedAndLoad` signature and callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d17d2f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->