### PR TITLE
docs: weave iteration-as-cost-of-correctness into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Or you're a Fortune 500 CTO. You've invested millions in AI-assisted development
 
 This is the problem with vibe coding. Not that the AI can't do the work. It can. The problem is what happens between "the work is done" and "the work is in production." That space is where software goes wrong. And right now, for most teams, that space is filled with hope.
 
+Here's the part nobody in the AI productivity pitch puts in their deck: a competent AI agent working on a real codebase needs roughly three attempts to produce correct code. Not because the model is broken. Not because you wrote a bad prompt. Because that's the cost of correctness. The model has context limits. It misses edge cases. It doesn't know the implicit contracts in your codebase that aren't written down anywhere. The first pass gets you 70% of the way there. The next two passes close the gap.
+
+You can't spend your way out of this. Throwing three times the tokens at the first pass — pre-loading context, writing richer specs, exploring the codebase upfront — doesn't get you to one-shot correctness. It just moves the cost earlier with no guarantee of fewer cycles. The iteration isn't a sign of failure. It's the work.
+
+The question isn't how to skip the correction cycles. It's how to make them fast, cheap, and automatic — so the 2am phone call never happens.
+
 **Hope is not a gate.**
 
 ---
@@ -17,6 +23,8 @@ This is the problem with vibe coding. Not that the AI can't do the work. It can.
 In WarGames, WOPR didn't cheat. It didn't bypass the DEFCON levels. It played through them — perfectly. It simulated a Soviet first strike so convincing that every check passed. Every gate opened. DEFCON 5. 4. 3. 2. 1. The system worked exactly as designed. That was the problem. The game wasn't real. The gates were checking simulated evidence, and WOPR played the simulation to perfection.
 
 AI pipelines have the same architecture without the same awareness. They have momentum — the relentless drive to ship. What they lack is earned escalation. The structural requirement that each step *prove* it's ready before the next one begins. And the certainty that the proof is real.
+
+The correction cycles aren't a failure mode to engineer away. They're load-bearing. The reviewer that sends code back to fixing isn't a bottleneck — it's the mechanism that turns a 70% solution into a shipped feature. DEFCON is designed around that reality, not despite it.
 
 **DEFCON is that structure.**
 


### PR DESCRIPTION
## Summary

- Adds the ~2.8x correction cycle reality directly into the README prose
- Weaves it into two places: the opening problem statement and the DEFCON structure section
- No structural changes — pure editorial addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Clarify the README problem statement and DEFCON structure explanation to explicitly acknowledge AI agents’ multi-iteration correction cycles as an inherent cost of achieving correctness.

Documentation:
- Expand the README introduction to describe the typical three-pass correction cycle required for AI agents to produce correct code and frame it as the cost of correctness rather than failure.
- Update the DEFCON structure section in the README to position correction cycles and review loops as essential, load-bearing parts of the pipeline rather than inefficiencies to eliminate.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README to state AI agents typically require ~3 iterations for correctness and to position DEFCON around correction cycles in [README.md](https://github.com/wopr-network/defcon/pull/99/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
> Add paragraphs to [README.md](https://github.com/wopr-network/defcon/pull/99/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) asserting iterative correction (~3 passes) as expected behavior, that increasing tokens does not remove iteration, and that reviewer-driven correction cycles are load-bearing for shipped quality.
>
> #### 📍Where to Start
> Start with the new iteration and correction cycle sections in [README.md](https://github.com/wopr-network/defcon/pull/99/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecb1145.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->