### PR TITLE
chore: fix bin path + add npm publish CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,11 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    uses: wopr-network/.github/.github/workflows/release.yml@main
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -61,5 +61,15 @@
     "onlyBuiltDependencies": [
       "better-sqlite3"
     ]
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "release": {
+    "extends": "@wopr-network/semantic-release-config"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wopr-network/defcon.git"
   }
 }


### PR DESCRIPTION
- Fix bin path: `dist/src/execution/cli.js` → `./dist/src/execution/cli.js` (npm rejected without `./`)
- Bump to 0.2.2 (0.2.1 already published but bin was stripped)
- Will add npm publish workflow in this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Release CI to publish npm package on main using NPM_TOKEN and bump version to 0.2.2 in [package.json](https://github.com/wopr-network/defcon/pull/103/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
> Add a reusable GitHub Actions workflow in [publish.yml](https://github.com/wopr-network/defcon/pull/103/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7) that runs on `main` and passes `NPM_TOKEN`; update [package.json](https://github.com/wopr-network/defcon/pull/103/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) with version 0.2.2, `publishConfig.access: public`, semantic-release config, and repository metadata.
>
> #### 📍Where to Start
> Start with the workflow configuration in [publish.yml](https://github.com/wopr-network/defcon/pull/103/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7) to see trigger and secret passing, then review release settings in [package.json](https://github.com/wopr-network/defcon/pull/103/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 059c9db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->