### PR TITLE
feat: add total_invocations Handlebars helper (WOP-1855)

### DIFF
--- a/src/engine/handlebars.ts
+++ b/src/engine/handlebars.ts
@@ -34,8 +34,8 @@ hbs.registerHelper("time_in_state", (entity: { updatedAt: string | Date }) =>
   String(Date.now() - new Date(entity.updatedAt).getTime()),
 );
 
-hbs.registerHelper("total_invocations", (entity: { invocations?: unknown[] }) =>
-  String(entity.invocations?.length ?? 0),
+hbs.registerHelper("total_invocations", (entity: { invocations?: { stage: string }[] }) =>
+  String(Array.isArray(entity.invocations) ? entity.invocations.length : 0),
 );
 
 const BUILTIN_HELPERS = new Set([

--- a/tests/engine/handlebars.test.ts
+++ b/tests/engine/handlebars.test.ts
@@ -57,6 +57,7 @@ describe("getHandlebars", () => {
     const tpl = hbs.compile("{{total_invocations entity}}");
     expect(tpl({ entity: { invocations: [{ stage: "review" }, { stage: "build" }] } })).toBe("2");
     expect(tpl({ entity: {} })).toBe("0");
+    expect(tpl({ entity: { invocations: [] } })).toBe("0");
   });
 
   it("has time_in_state helper registered", () => {


### PR DESCRIPTION
## Summary
- Adds missing `total_invocations` Handlebars helper to match vision spec
- Returns count of entity invocations as string (returns "0" if none)
- Fixes silent empty-string output for templates using `{{total_invocations entity}}`

Fixes WOP-1855

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a Handlebars helper to expose total entity invocations and cover it with tests.

New Features:
- Introduce a total_invocations Handlebars helper that returns the number of invocations on an entity as a string.

Tests:
- Add tests verifying the total_invocations helper is registered and returns the correct counts for entities with and without invocations.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `total_invocations` Handlebars helper in [handlebars.ts](https://github.com/wopr-network/defcon/pull/104/files#diff-bbe323e242506cd2ebc3fe55c01aff2322ce6798cf32458096eea2f007aba3b1) to return the count of `entity.invocations` as a string for WOP-1855
> Introduce `total_invocations` helper and include it in `BUILTIN_HELPERS` in [handlebars.ts](https://github.com/wopr-network/defcon/pull/104/files#diff-bbe323e242506cd2ebc3fe55c01aff2322ce6798cf32458096eea2f007aba3b1); add tests in [handlebars.test.ts](https://github.com/wopr-network/defcon/pull/104/files#diff-2de60c55ac3478aa8a3ea3164aa506dd203d26377b4811e9084996cd6e9e8ddf) covering array, missing, and empty cases.
>
> #### 📍Where to Start
> Start with the `registerHelper('total_invocations', ...)` implementation in [handlebars.ts](https://github.com/wopr-network/defcon/pull/104/files#diff-bbe323e242506cd2ebc3fe55c01aff2322ce6798cf32458096eea2f007aba3b1).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2007d14. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `total_invocations` helper that displays the count of invocations for an entity in templates.

* **Tests**
  * Added test coverage validating the new helper behavior with various invocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->