### PR TITLE
refactor: typed error classes instead of raw Error strings (WOP-1857)

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -1,3 +1,4 @@
+import { NotFoundError, ValidationError } from "../errors.js";
 import type { Logger } from "../logger.js";
 import { consoleLogger } from "../logger.js";
 import type {
@@ -89,22 +90,22 @@ export class Engine {
   ): Promise<ProcessSignalResult> {
     // 1. Load entity
     const entity = await this.entityRepo.get(entityId);
-    if (!entity) throw new Error(`Entity "${entityId}" not found`);
+    if (!entity) throw new NotFoundError(`Entity "${entityId}" not found`);
 
     // 2. Load flow
     const flow = await this.flowRepo.get(entity.flowId);
-    if (!flow) throw new Error(`Flow "${entity.flowId}" not found`);
+    if (!flow) throw new NotFoundError(`Flow "${entity.flowId}" not found`);
 
     // 3. Find transition
     const transition = findTransition(flow, entity.state, signal, { entity }, true, this.logger);
     if (!transition)
-      throw new Error(`No transition from "${entity.state}" on signal "${signal}" in flow "${flow.name}"`);
+      throw new ValidationError(`No transition from "${entity.state}" on signal "${signal}" in flow "${flow.name}"`);
 
     // 4. Evaluate gate if present
     const gatesPassed: string[] = [];
     if (transition.gateId) {
       const gate = await this.gateRepo.get(transition.gateId);
-      if (!gate) throw new Error(`Gate "${transition.gateId}" not found`);
+      if (!gate) throw new NotFoundError(`Gate "${transition.gateId}" not found`);
 
       const gateResult = await evaluateGate(gate, entity, this.gateRepo, flow.gateTimeoutMs);
       if (!gateResult.passed) {
@@ -321,7 +322,7 @@ export class Engine {
     refs?: Record<string, { adapter: string; id: string; [key: string]: unknown }>,
   ): Promise<Entity> {
     const flow = await this.flowRepo.getByName(flowName);
-    if (!flow) throw new Error(`Flow "${flowName}" not found`);
+    if (!flow) throw new NotFoundError(`Flow "${flowName}" not found`);
 
     const entity = await this.entityRepo.create(flow.id, flow.initialState, refs);
 
@@ -345,7 +346,7 @@ export class Engine {
           error: onEnterResult.error,
           emittedAt: new Date(),
         });
-        throw new Error(`onEnter failed for entity ${entity.id}: ${onEnterResult.error}`);
+        throw new ValidationError(`onEnter failed for entity ${entity.id}: ${onEnterResult.error}`);
       }
       if (onEnterResult.artifacts) {
         await this.eventEmitter.emit({

--- a/src/engine/flow-spawner.ts
+++ b/src/engine/flow-spawner.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from "../errors.js";
 import type { Logger } from "../logger.js";
 import { consoleLogger } from "../logger.js";
 import type { Entity, IEntityRepository, IFlowRepository, Transition } from "../repositories/interfaces.js";
@@ -17,7 +18,7 @@ export async function executeSpawn(
   if (!transition.spawnFlow) return null;
 
   const flow = await flowRepo.getByName(transition.spawnFlow);
-  if (!flow) throw new Error(`Spawn flow "${transition.spawnFlow}" not found`);
+  if (!flow) throw new NotFoundError(`Spawn flow "${transition.spawnFlow}" not found`);
 
   const childEntity = await entityRepo.create(flow.id, flow.initialState, parentEntity.refs ?? undefined);
 

--- a/src/engine/gate-evaluator.ts
+++ b/src/engine/gate-evaluator.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { GateError, NotFoundError, ValidationError } from "../errors.js";
 import type { Entity, Gate, IGateRepository } from "../repositories/interfaces.js";
 import { validateGateCommand } from "./gate-command-validator.js";
 import { checkSsrf } from "./ssrf-guard.js";
@@ -164,7 +165,7 @@ export async function evaluateGate(
       }
     }
   } else {
-    throw new Error(`Unknown gate type: ${gate.type}`);
+    throw new GateError(`Unknown gate type: ${gate.type}`);
   }
 
   await gateRepo.record(entity.id, gate.id, passed, output);
@@ -179,7 +180,7 @@ async function runFunction(
 ): Promise<{ passed: boolean; output: string; timedOut: boolean }> {
   const lastColon = functionRef.lastIndexOf(":");
   if (lastColon === -1) {
-    throw new Error(`Invalid functionRef "${functionRef}" — expected "path:exportName"`);
+    throw new ValidationError(`Invalid functionRef "${functionRef}" — expected "path:exportName"`);
   }
   const modulePath = functionRef.slice(0, lastColon);
   const exportName = functionRef.slice(lastColon + 1);
@@ -196,14 +197,14 @@ async function runFunction(
     realPath = absPath;
   }
   if (!realPath.startsWith(GATES_DIR)) {
-    throw new Error("functionRef must resolve to a path inside the gates/ directory");
+    throw new ValidationError("functionRef must resolve to a path inside the gates/ directory");
   }
   const moduleUrl = pathToFileURL(realPath).href;
 
   const mod = await import(moduleUrl);
   const fn = mod[exportName];
   if (typeof fn !== "function") {
-    throw new Error(`Gate function "${exportName}" not found in ${modulePath}`);
+    throw new NotFoundError(`Gate function "${exportName}" not found in ${modulePath}`);
   }
 
   const timeout = effectiveTimeout;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,30 @@
+export class DefconError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "DefconError";
+  }
+}
+export class NotFoundError extends DefconError {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "NotFoundError";
+  }
+}
+export class ConflictError extends DefconError {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "ConflictError";
+  }
+}
+export class ValidationError extends DefconError {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "ValidationError";
+  }
+}
+export class GateError extends DefconError {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "GateError";
+  }
+}

--- a/src/execution/active-runner.ts
+++ b/src/execution/active-runner.ts
@@ -1,4 +1,5 @@
 import type { Engine, ProcessSignalResult } from "../engine/engine.js";
+import { NotFoundError } from "../errors.js";
 import type { Logger } from "../logger.js";
 import { consoleLogger } from "../logger.js";
 import type {
@@ -64,7 +65,7 @@ export class ActiveRunner {
     let flowId: string | undefined;
     if (flowName) {
       const flow = await this.flowRepo.getByName(flowName);
-      if (!flow) throw new Error(`Flow "${flowName}" not found`);
+      if (!flow) throw new NotFoundError(`Flow "${flowName}" not found`);
       flowId = flow.id;
     }
     while (true) {

--- a/src/repositories/drizzle/entity.repo.ts
+++ b/src/repositories/drizzle/entity.repo.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, isNull, lt, not } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { NotFoundError } from "../../errors.js";
 import type { Artifacts, Entity, IEntityRepository, Refs } from "../interfaces.js";
 import type * as schema from "./schema.js";
 import { entities } from "./schema.js";
@@ -83,7 +84,7 @@ export class DrizzleEntityRepository implements IEntityRepository {
   ): Promise<Entity> {
     return this.db.transaction((tx) => {
       const rows = tx.select().from(entities).where(eq(entities.id, id)).limit(1).all();
-      if (rows.length === 0) throw new Error(`Entity not found: ${id}`);
+      if (rows.length === 0) throw new NotFoundError(`Entity not found: ${id}`);
       const row = rows[0];
       const now = Date.now();
       const mergedArtifacts = artifacts
@@ -106,7 +107,7 @@ export class DrizzleEntityRepository implements IEntityRepository {
 
   async updateArtifacts(id: string, artifacts: Partial<Artifacts>): Promise<void> {
     const rows = await this.db.select().from(entities).where(eq(entities.id, id)).limit(1);
-    if (rows.length === 0) throw new Error(`Entity not found: ${id}`);
+    if (rows.length === 0) throw new NotFoundError(`Entity not found: ${id}`);
     const existing = (rows[0].artifacts as Record<string, unknown>) ?? {};
     await this.db
       .update(entities)
@@ -164,7 +165,7 @@ export class DrizzleEntityRepository implements IEntityRepository {
   ): Promise<void> {
     this.db.transaction((tx) => {
       const rows = tx.select().from(entities).where(eq(entities.id, parentId)).limit(1).all();
-      if (rows.length === 0) throw new Error(`Entity ${parentId} not found`);
+      if (rows.length === 0) throw new NotFoundError(`Entity ${parentId} not found`);
       const row = rows[0];
       const artifacts = (row.artifacts as Record<string, unknown>) ?? {};
       const existing = (Array.isArray(artifacts.spawnedChildren) ? artifacts.spawnedChildren : []) as Array<{

--- a/src/repositories/drizzle/flow.repo.ts
+++ b/src/repositories/drizzle/flow.repo.ts
@@ -1,5 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { NotFoundError } from "../../errors.js";
 import type {
   CreateFlowInput,
   CreateStateInput,
@@ -144,7 +145,7 @@ export class DrizzleFlowRepository implements IFlowRepository {
   async update(id: string, changes: UpdateFlowInput): Promise<Flow> {
     const now = Date.now();
     const current = this.db.select().from(flowDefinitions).where(eq(flowDefinitions.id, id)).all();
-    if (current.length === 0) throw new Error(`Flow not found: ${id}`);
+    if (current.length === 0) throw new NotFoundError(`Flow not found: ${id}`);
 
     const updateValues: Record<string, unknown> = { updatedAt: now };
     if (changes.name !== undefined) updateValues.name = changes.name;
@@ -189,7 +190,7 @@ export class DrizzleFlowRepository implements IFlowRepository {
 
   async updateState(stateId: string, changes: UpdateStateInput): Promise<State> {
     const existing = this.db.select().from(stateDefinitions).where(eq(stateDefinitions.id, stateId)).all();
-    if (existing.length === 0) throw new Error(`State not found: ${stateId}`);
+    if (existing.length === 0) throw new NotFoundError(`State not found: ${stateId}`);
 
     const updateValues: Record<string, unknown> = {};
     if (changes.name !== undefined) updateValues.name = changes.name;
@@ -234,7 +235,7 @@ export class DrizzleFlowRepository implements IFlowRepository {
 
   async updateTransition(transitionId: string, changes: UpdateTransitionInput): Promise<Transition> {
     const existing = this.db.select().from(transitionRules).where(eq(transitionRules.id, transitionId)).all();
-    if (existing.length === 0) throw new Error(`Transition not found: ${transitionId}`);
+    if (existing.length === 0) throw new NotFoundError(`Transition not found: ${transitionId}`);
 
     const updateValues: Record<string, unknown> = {};
     if (changes.fromState !== undefined) updateValues.fromState = changes.fromState;
@@ -258,7 +259,7 @@ export class DrizzleFlowRepository implements IFlowRepository {
 
   async snapshot(flowId: string): Promise<FlowVersion> {
     const flow = await this.get(flowId);
-    if (!flow) throw new Error(`Flow not found: ${flowId}`);
+    if (!flow) throw new NotFoundError(`Flow not found: ${flowId}`);
 
     const now = Date.now();
     const id = crypto.randomUUID();
@@ -320,7 +321,7 @@ export class DrizzleFlowRepository implements IFlowRepository {
       .from(flowVersions)
       .where(and(eq(flowVersions.flowId, flowId), eq(flowVersions.version, version)))
       .all();
-    if (versionRows.length === 0) throw new Error(`Version ${version} not found for flow ${flowId}`);
+    if (versionRows.length === 0) throw new NotFoundError(`Version ${version} not found for flow ${flowId}`);
 
     const snap = versionRows[0].snapshot as {
       name: string;

--- a/src/repositories/drizzle/gate.repo.ts
+++ b/src/repositories/drizzle/gate.repo.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { asc, eq, sql } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { NotFoundError } from "../../errors.js";
 import type { CreateGateInput, Gate, GateResult, IGateRepository } from "../interfaces.js";
 import type * as schema from "./schema.js";
 import { gateDefinitions, gateResults } from "./schema.js";
@@ -50,7 +51,7 @@ export class DrizzleGateRepository implements IGateRepository {
     };
     this.db.insert(gateDefinitions).values(values).run();
     const row = this.db.select().from(gateDefinitions).where(eq(gateDefinitions.id, id)).get();
-    if (!row) throw new Error(`Gate ${id} not found after insert`);
+    if (!row) throw new NotFoundError(`Gate ${id} not found after insert`);
     return toGate(row);
   }
 
@@ -84,7 +85,7 @@ export class DrizzleGateRepository implements IGateRepository {
       })
       .run();
     const row = this.db.select().from(gateResults).where(eq(gateResults.id, id)).get();
-    if (!row) throw new Error(`GateResult ${id} not found after insert`);
+    if (!row) throw new NotFoundError(`GateResult ${id} not found after insert`);
     return toGateResult(row);
   }
 
@@ -96,7 +97,7 @@ export class DrizzleGateRepository implements IGateRepository {
   ): Promise<Gate> {
     this.db.update(gateDefinitions).set(changes).where(eq(gateDefinitions.id, id)).run();
     const row = this.db.select().from(gateDefinitions).where(eq(gateDefinitions.id, id)).get();
-    if (!row) throw new Error(`Gate ${id} not found after update`);
+    if (!row) throw new NotFoundError(`Gate ${id} not found after update`);
     return toGate(row);
   }
 

--- a/src/repositories/drizzle/invocation.repo.ts
+++ b/src/repositories/drizzle/invocation.repo.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, isNotNull, isNull, sql } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { ConflictError, NotFoundError } from "../../errors.js";
 import type { Artifacts, IInvocationRepository, Invocation, Mode } from "../interfaces.js";
 import type * as schema from "./schema.js";
 import { entities, invocations } from "./schema.js";
@@ -52,7 +53,7 @@ export class DrizzleInvocationRepository implements IInvocationRepository {
       })
       .run();
     const created = await this.get(id);
-    if (!created) throw new Error(`Invocation ${id} not found after insert`);
+    if (!created) throw new NotFoundError(`Invocation ${id} not found after insert`);
     return created;
   }
 
@@ -89,14 +90,14 @@ export class DrizzleInvocationRepository implements IInvocationRepository {
 
     if (result.changes === 0) {
       const existing = this.db.select().from(invocations).where(eq(invocations.id, id)).all();
-      if (existing.length === 0) throw new Error(`Invocation ${id} not found`);
-      if (existing[0].completedAt) throw new Error(`Invocation ${id} already completed`);
-      if (existing[0].failedAt) throw new Error(`Invocation ${id} already failed`);
-      throw new Error(`Invocation ${id} concurrent modification detected`);
+      if (existing.length === 0) throw new NotFoundError(`Invocation ${id} not found`);
+      if (existing[0].completedAt) throw new ConflictError(`Invocation ${id} already completed`);
+      if (existing[0].failedAt) throw new ConflictError(`Invocation ${id} already failed`);
+      throw new ConflictError(`Invocation ${id} concurrent modification detected`);
     }
 
     const row = this.db.select().from(invocations).where(eq(invocations.id, id)).all();
-    if (row.length === 0) throw new Error(`Invocation ${id} not found after update`);
+    if (row.length === 0) throw new NotFoundError(`Invocation ${id} not found after update`);
     return toInvocation(row[0]);
   }
 
@@ -109,14 +110,14 @@ export class DrizzleInvocationRepository implements IInvocationRepository {
 
     if (result.changes === 0) {
       const existing = this.db.select().from(invocations).where(eq(invocations.id, id)).all();
-      if (existing.length === 0) throw new Error(`Invocation ${id} not found`);
-      if (existing[0].completedAt) throw new Error(`Invocation ${id} already completed`);
-      if (existing[0].failedAt) throw new Error(`Invocation ${id} already failed`);
-      throw new Error(`Invocation ${id} concurrent modification detected`);
+      if (existing.length === 0) throw new NotFoundError(`Invocation ${id} not found`);
+      if (existing[0].completedAt) throw new ConflictError(`Invocation ${id} already completed`);
+      if (existing[0].failedAt) throw new ConflictError(`Invocation ${id} already failed`);
+      throw new ConflictError(`Invocation ${id} concurrent modification detected`);
     }
 
     const row = this.db.select().from(invocations).where(eq(invocations.id, id)).all();
-    if (row.length === 0) throw new Error(`Invocation ${id} not found after update`);
+    if (row.length === 0) throw new NotFoundError(`Invocation ${id} not found after update`);
     return toInvocation(row[0]);
   }
 


### PR DESCRIPTION
## Summary
- Adds `src/errors.ts` with DefconError, NotFoundError, ConflictError, ValidationError, GateError
- Replaces raw `new Error()` throws in repository layer, engine, gate-evaluator, adapters, and execution
- Enables catch-by-type without string matching

Closes WOP-1857

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Introduce typed domain-specific error classes and replace generic errors across repositories, engine, and gate evaluation to support more precise error handling.

New Features:
- Add a shared DefconError base class with specialized NotFoundError, ConflictError, ValidationError, and GateError types.

Enhancements:
- Update engine, repositories, gate evaluator, flow spawner, and execution runner to throw typed errors instead of generic Error instances in common failure scenarios.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace raw string errors with typed errors across engine, repositories, and gate evaluation to standardize failure modes (WOP-1857)
> Introduce `DefconError` base and typed errors (`NotFoundError`, `ValidationError`, `ConflictError`, `GateError`) and refactor engine signal processing, entity creation, gate evaluation, runner start, and Drizzle repositories to throw these types instead of generic `Error`.
>
> #### 📍Where to Start
> Start with the error definitions in [src/errors.ts](https://github.com/wopr-network/defcon/pull/106/files#diff-55db69e02ff5714d444d8081ec6ecac5d9833fb29fda64d1e829e5766434fdc0), then follow how they are used in `Engine.processSignal` and `Engine.createEntity` in [src/engine/engine.ts](https://github.com/wopr-network/defcon/pull/106/files#diff-4cbf43f37f351f7f4cd5559150b9abeddc2ecfec94280eb6080e03a575e75f6d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebc58a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->