### PR TITLE
chore: update norad → radar reference in comment

### DIFF
--- a/src/api/wire-types.ts
+++ b/src/api/wire-types.ts
@@ -1,6 +1,6 @@
 /**
  * Wire types for defcon's REST and MCP APIs.
- * Exported for consumers (e.g. norad) to import instead of duplicating.
+ * Exported for consumers (e.g. radar) to import instead of duplicating.
  */
 
 export type ClaimResponse =


### PR DESCRIPTION
Part of WOP-1947 rename.

Updates a single comment in `wire-types.ts` that referenced the old `norad` consumer name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Chores:
- Refresh an internal code comment to use the new radar consumer name instead of the deprecated norad name.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update header comment in `src/api/wire-types.ts` to replace 'norad' with 'radar' for comment consistency
> Replace the example consumer name in the file header comment from 'norad' to 'radar' in [wire-types.ts](https://github.com/wopr-network/defcon/pull/115/files#diff-3daf581caddfa5575f33227ff2e3ce0d014eb40046dc314ec5719e819f63212d).
>
> #### 📍Where to Start
> Start with the file header comment in [wire-types.ts](https://github.com/wopr-network/defcon/pull/115/files#diff-3daf581caddfa5575f33227ff2e3ce0d014eb40046dc314ec5719e819f63212d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55546e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->