### PR TITLE
fix: post-merge review findings from WOP-1949 admin controls

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -295,27 +295,27 @@ export function createHttpServer(deps: HttpServerDeps): http.Server {
   });
 
   // --- Admin: Drain/Undrain Worker ---
-  router.add("POST", "/api/admin/workers/:workerId/drain", async (req) => {
+  router.add("POST", "/api/admin/workers/:worker_id/drain", async (req) => {
     const authErr = requireAdminToken(deps, req);
     if (authErr) return authErr;
     const callerToken = extractBearerToken(req.authorization);
     const result = await callToolHandler(
       deps.mcpDeps,
       "admin.worker.drain",
-      { worker_id: req.params.workerId },
+      { worker_id: req.params.worker_id },
       { adminToken: deps.adminToken, callerToken },
     );
     return mcpResultToApi(result);
   });
 
-  router.add("POST", "/api/admin/workers/:workerId/undrain", async (req) => {
+  router.add("POST", "/api/admin/workers/:worker_id/undrain", async (req) => {
     const authErr = requireAdminToken(deps, req);
     if (authErr) return authErr;
     const callerToken = extractBearerToken(req.authorization);
     const result = await callToolHandler(
       deps.mcpDeps,
       "admin.worker.undrain",
-      { worker_id: req.params.workerId },
+      { worker_id: req.params.worker_id },
       { adminToken: deps.adminToken, callerToken },
     );
     return mcpResultToApi(result);

--- a/src/execution/mcp-server.ts
+++ b/src/execution/mcp-server.ts
@@ -900,6 +900,7 @@ async function handleAdminFlowPause(deps: McpServerDeps, args: Record<string, un
   if (!v.ok) return v.result;
   const flow = await deps.flows.getByName(v.data.flow_name);
   if (!flow) return errorResult(`Flow not found: ${v.data.flow_name}`);
+  await deps.flows.snapshot(flow.id);
   await deps.flows.update(flow.id, { paused: true });
   emitDefinitionChanged(deps.eventRepo, flow.id, "admin.flow.pause", { name: v.data.flow_name });
   return jsonResult({ paused: true, flow: v.data.flow_name });
@@ -910,6 +911,7 @@ async function handleAdminFlowResume(deps: McpServerDeps, args: Record<string, u
   if (!v.ok) return v.result;
   const flow = await deps.flows.getByName(v.data.flow_name);
   if (!flow) return errorResult(`Flow not found: ${v.data.flow_name}`);
+  await deps.flows.snapshot(flow.id);
   await deps.flows.update(flow.id, { paused: false });
   emitDefinitionChanged(deps.eventRepo, flow.id, "admin.flow.resume", { name: v.data.flow_name });
   return jsonResult({ paused: false, flow: v.data.flow_name });
@@ -920,6 +922,10 @@ async function handleAdminEntityCancel(deps: McpServerDeps, args: Record<string,
   if (!v.ok) return v.result;
   const entity = await deps.entities.get(v.data.entity_id);
   if (!entity) return errorResult(`Entity not found: ${v.data.entity_id}`);
+  const flow = await deps.flows.get(entity.flowId);
+  if (!flow) return errorResult(`Flow not found for entity: ${v.data.entity_id}`);
+  const cancelledState = flow.states.find((s) => s.name === "cancelled");
+  if (!cancelledState) return errorResult(`State 'cancelled' not found in flow '${flow.name}'`);
   const invocations = await deps.invocations.findByEntity(v.data.entity_id);
   for (const inv of invocations) {
     if (inv.completedAt === null && inv.failedAt === null) {
@@ -927,6 +933,14 @@ async function handleAdminEntityCancel(deps: McpServerDeps, args: Record<string,
     }
   }
   await deps.entities.cancelEntity(v.data.entity_id);
+  await deps.transitions.record({
+    entityId: v.data.entity_id,
+    fromState: entity.state,
+    toState: "cancelled",
+    trigger: "admin.cancel",
+    invocationId: null,
+    timestamp: new Date(),
+  });
   return jsonResult({ cancelled: true, entity_id: v.data.entity_id });
 }
 
@@ -946,6 +960,14 @@ async function handleAdminEntityReset(deps: McpServerDeps, args: Record<string, 
     }
   }
   const updated = await deps.entities.resetEntity(v.data.entity_id, v.data.target_state);
+  await deps.transitions.record({
+    entityId: v.data.entity_id,
+    fromState: entity.state,
+    toState: updated.state,
+    trigger: "admin.reset",
+    invocationId: null,
+    timestamp: new Date(),
+  });
   return jsonResult({ reset: true, entity_id: v.data.entity_id, state: updated.state });
 }
 

--- a/src/repositories/drizzle/gate.repo.ts
+++ b/src/repositories/drizzle/gate.repo.ts
@@ -112,7 +112,7 @@ export class DrizzleGateRepository implements IGateRepository {
   }
 
   async clearResult(entityId: string, gateId: string): Promise<void> {
-    this.db
+    await this.db
       .delete(gateResults)
       .where(and(eq(gateResults.entityId, entityId), eq(gateResults.gateId, gateId)))
       .run();


### PR DESCRIPTION
## Summary
Follow-up fixes for bugs that landed in main via PR #117 (WOP-1949), caught in post-merge re-review.

- `await` missing on `db.delete()` in `clearResult`
- `transitions.record()` added for `cancel` and `reset` admin actions (audit trail)
- `cancelEntity` now validates `cancelled` state against the entity's flow
- `snapshot()` called before `pause`/`resume` flow updates
- Route params renamed `:workerId` → `:worker_id` (snake_case per CLAUDE.md)

Closes follow-up from WOP-1949 reviewer findings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Address post-merge issues in admin flow and worker controls to ensure correct state handling, auditing, and API consistency.

Bug Fixes:
- Ensure gate result deletions are awaited in clearResult to avoid race conditions or incomplete cleanup.
- Validate that an entity's flow defines a 'cancelled' state before allowing admin-driven cancellation to proceed.
- Capture snapshots before pausing or resuming flows via admin actions so state changes are recorded consistently.
- Align admin worker drain/undrain routes and parameters to snake_case to match documented API contracts.

Enhancements:
- Record transition audit entries for admin entity cancel and reset actions, including from/to states and triggers for better traceability.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align admin worker routes to `:worker_id`, snapshot flows on pause/resume, and record `admin.cancel`/`admin.reset` transitions in [`mcp-server.ts`](https://github.com/wopr-network/defcon/pull/118/files#diff-495f500d6fc22865df5a220b2d57ce7f3cfe1b07a0c4340459054f3bd915188e)
> Update admin worker HTTP routes to `:worker_id`, add flow snapshots before pause/resume, validate cancel prerequisites, and write transitions for cancel/reset; also await gate result deletion in [`gate.repo.ts`](https://github.com/wopr-network/defcon/pull/118/files#diff-36a882b73a2407eecb4b5244d545818a5f8df105dcd9135719de3d44d78dee2a).
>
> #### 📍Where to Start
> Start with admin handlers in [`mcp-server.ts`](https://github.com/wopr-network/defcon/pull/118/files#diff-495f500d6fc22865df5a220b2d57ce7f3cfe1b07a0c4340459054f3bd915188e), then review route changes in [`server.ts`](https://github.com/wopr-network/defcon/pull/118/files#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a28c723. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added flow snapshots on pause/resume operations for better state tracking
  * Added transition logging for admin cancel and reset operations to improve visibility into administrative actions

* **Bug Fixes**
  * Improved asynchronous operation handling to ensure data deletion completes reliably

* **Chores**
  * Standardized admin route parameters for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->