### PR TITLE
fix: use AdminFlowRestoreSchema in handleAdminFlowResume; add @types/ws

### DIFF
--- a/src/execution/mcp-server.ts
+++ b/src/execution/mcp-server.ts
@@ -907,7 +907,7 @@ async function handleAdminFlowPause(deps: McpServerDeps, args: Record<string, un
 }
 
 async function handleAdminFlowResume(deps: McpServerDeps, args: Record<string, unknown>) {
-  const v = validateInput(AdminFlowPauseSchema, args);
+  const v = validateInput(AdminFlowRestoreSchema, args);
   if (!v.ok) return v.result;
   const flow = await deps.flows.getByName(v.data.flow_name);
   if (!flow) return errorResult(`Flow not found: ${v.data.flow_name}`);


### PR DESCRIPTION
## Summary
- `handleAdminFlowResume` was validating input with `AdminFlowPauseSchema` (copy-paste bug from the pause handler above it) — corrected to `AdminFlowRestoreSchema`
- Adds `@types/ws` devDependency which was missing, causing `tsc --noEmit` errors introduced by the WOP-1948 WebSocket broadcast PR (#116)

## No backwards-compat shim for route rename
Per CLAUDE.md, no backwards-compatibility hacks. The `:worker_id` snake_case rename in #118 is correct and final.

Caught by post-merge re-review of WOP-1949 (#117, #118).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/defcon/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Correct admin flow resume validation and address missing WebSocket type dependency.

Bug Fixes:
- Fix admin flow resume handler to validate input using the AdminFlowRestoreSchema instead of the pause schema.

Build:
- Add @types/ws as a devDependency to satisfy TypeScript checks for WebSocket usage.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate admin flow resume args with `AdminFlowRestoreSchema` in `handleAdminFlowResume` in [mcp-server.ts](https://github.com/wopr-network/defcon/pull/119/files#diff-495f500d6fc22865df5a220b2d57ce7f3cfe1b07a0c4340459054f3bd915188e) and add `@types/ws` for type coverage
> Switch `handleAdminFlowResume` argument validation to `AdminFlowRestoreSchema` in [mcp-server.ts](https://github.com/wopr-network/defcon/pull/119/files#diff-495f500d6fc22865df5a220b2d57ce7f3cfe1b07a0c4340459054f3bd915188e) and add `@types/ws`.
>
> #### 📍Where to Start
> Start at the `handleAdminFlowResume` handler in [mcp-server.ts](https://github.com/wopr-network/defcon/pull/119/files#diff-495f500d6fc22865df5a220b2d57ce7f3cfe1b07a0c4340459054f3bd915188e).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized efbfcfc. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->