### PR TITLE
feat: support comma-separated DEFCON_CORS_ORIGIN for multiple allowed origins

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -19,7 +19,7 @@ export interface HttpServerDeps {
   mcpDeps: McpServerDeps;
   adminToken?: string;
   workerToken?: string;
-  corsOrigin?: string; // explicit CORS origin, or undefined for loopback default
+  corsOrigins?: string[]; // explicit CORS origins, or undefined for loopback default
   logger?: Logger;
 }
 
@@ -344,8 +344,8 @@ export function createHttpServer(deps: HttpServerDeps): http.Server {
         /^https?:\/\/localhost(:\d+)?$/.test(origin) ||
         /^https?:\/\/127\.0\.0\.1(:\d+)?$/.test(origin) ||
         /^https?:\/\/\[::1\](:\d+)?$/.test(origin);
-      const corsAllowed = deps.corsOrigin
-        ? origin === deps.corsOrigin // explicit origin: exact match only
+      const corsAllowed = deps.corsOrigins
+        ? deps.corsOrigins.includes(origin) // explicit origins: set membership check
         : isLoopbackOrigin; // loopback mode: only reflect loopback origins
       if (corsAllowed) {
         res.setHeader("Vary", "Origin");

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,23 +1,29 @@
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 
 export interface CorsOriginResult {
-  /** Explicit allowed origin, or null meaning "loopback-only default pattern" */
-  origin: string | null;
+  /** Explicit allowed origins, or null meaning "loopback-only default pattern" */
+  origins: string[] | null;
 }
 
 export function resolveCorsOrigin(opts: { host: string; corsEnv: string | undefined }): CorsOriginResult {
   const corsValue = opts.corsEnv?.trim() || undefined;
   const isLoopback = LOOPBACK_HOSTS.has(opts.host);
 
-  // If explicit origin provided, validate and use it
+  // If explicit origins provided, validate each and use them
   if (corsValue) {
-    if (!/^https?:\/\/[^/]+$/.test(corsValue)) {
-      throw new Error(
-        `DEFCON_CORS_ORIGIN must be a bare origin like https://app.example.com, not ${corsValue}. ` +
-          "Remove any path component or trailing slash.",
-      );
+    const entries = corsValue
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const entry of entries) {
+      if (!/^https?:\/\/[^/]+$/.test(entry)) {
+        throw new Error(
+          `DEFCON_CORS_ORIGIN must be bare origins like https://app.example.com (comma-separated for multiple), not ${entry}. ` +
+            "Remove any path component or trailing slash.",
+        );
+      }
     }
-    return { origin: corsValue };
+    return { origins: entries };
   }
 
   // Non-loopback without explicit origin — refuse to start
@@ -25,10 +31,11 @@ export function resolveCorsOrigin(opts: { host: string; corsEnv: string | undefi
     throw new Error(
       `DEFCON_CORS_ORIGIN must be set when binding to non-loopback address "${opts.host}". ` +
         "Without an explicit CORS origin, any website on the network can make cross-origin requests to this server. " +
-        'Set DEFCON_CORS_ORIGIN to the allowed origin (e.g. "https://my-app.example.com") or use a loopback address.',
+        'Set DEFCON_CORS_ORIGIN to the allowed origin (e.g. "https://my-app.example.com") or use a loopback address. ' +
+        "Multiple origins can be separated by commas.",
     );
   }
 
   // Loopback without explicit origin — use default pattern
-  return { origin: null };
+  return { origins: null };
 }

--- a/src/execution/cli.ts
+++ b/src/execution/cli.ts
@@ -287,7 +287,7 @@ program
         mcpDeps: deps,
         adminToken,
         workerToken,
-        corsOrigin: restCorsResult.origin ?? undefined,
+        corsOrigins: restCorsResult.origins ?? undefined,
       });
       if (adminToken) {
         const wsBroadcaster = new WebSocketBroadcaster({
@@ -324,18 +324,14 @@ program
         sqlite.close();
         process.exit(1);
       }
-      const allowedOriginPattern: RegExp | string | null = corsResult.origin
-        ? corsResult.origin // exact string match
-        : /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/; // loopback default
+      const allowedOriginSet: Set<string> | null = corsResult.origins ? new Set(corsResult.origins) : null;
+      const loopbackPattern = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/;
 
       const httpServer = http.createServer(async (req, res) => {
         // CORS: restrict to localhost origins when bound to loopback; require DEFCON_CORS_ORIGIN when bound to non-loopback
         const origin = req.headers.origin;
         if (origin) {
-          const originAllowed =
-            typeof allowedOriginPattern === "string"
-              ? origin === allowedOriginPattern
-              : allowedOriginPattern.test(origin);
+          const originAllowed = allowedOriginSet ? allowedOriginSet.has(origin) : loopbackPattern.test(origin);
           if (originAllowed) {
             res.setHeader("Vary", "Origin");
             res.setHeader("Access-Control-Allow-Origin", origin);

--- a/tests/api/server.test.ts
+++ b/tests/api/server.test.ts
@@ -301,7 +301,7 @@ describe("HTTP Server - explicit CORS origin", () => {
 
   beforeAll(async () => {
     deps = makeTestDeps();
-    deps.corsOrigin = "https://app.example.com";
+    deps.corsOrigins = ["https://app.example.com"];
     server = createHttpServer(deps);
     port = await listen(server);
   });

--- a/tests/cors-integration.test.ts
+++ b/tests/cors-integration.test.ts
@@ -6,14 +6,22 @@ describe("CORS origin enforcement (integration)", () => {
     expect(() => resolveCorsOrigin({ host: "0.0.0.0", corsEnv: undefined })).toThrow(/DEFCON_CORS_ORIGIN must be set/);
   });
 
-  it("non-loopback host with env var succeeds", () => {
+  it("non-loopback host with single origin env var succeeds", () => {
     const result = resolveCorsOrigin({ host: "0.0.0.0", corsEnv: "https://app.example.com" });
-    expect(result.origin).toBe("https://app.example.com");
+    expect(result.origins).toEqual(["https://app.example.com"]);
+  });
+
+  it("non-loopback host with comma-separated origins succeeds", () => {
+    const result = resolveCorsOrigin({
+      host: "0.0.0.0",
+      corsEnv: "https://app.example.com,http://localhost:3000",
+    });
+    expect(result.origins).toEqual(["https://app.example.com", "http://localhost:3000"]);
   });
 
   it("loopback host without env var returns null (default pattern)", () => {
     const result = resolveCorsOrigin({ host: "127.0.0.1", corsEnv: undefined });
-    expect(result.origin).toBeNull();
+    expect(result.origins).toBeNull();
   });
 
   it("error message mentions the bound host", () => {

--- a/tests/cors.test.ts
+++ b/tests/cors.test.ts
@@ -3,15 +3,15 @@ import { resolveCorsOrigin } from "../src/cors.js";
 
 describe("resolveCorsOrigin", () => {
   it("returns null for loopback 127.0.0.1 (no restriction needed)", () => {
-    expect(resolveCorsOrigin({ host: "127.0.0.1", corsEnv: undefined })).toEqual({ origin: null });
+    expect(resolveCorsOrigin({ host: "127.0.0.1", corsEnv: undefined })).toEqual({ origins: null });
   });
 
   it("returns null for loopback localhost", () => {
-    expect(resolveCorsOrigin({ host: "localhost", corsEnv: undefined })).toEqual({ origin: null });
+    expect(resolveCorsOrigin({ host: "localhost", corsEnv: undefined })).toEqual({ origins: null });
   });
 
   it("returns null for loopback ::1", () => {
-    expect(resolveCorsOrigin({ host: "::1", corsEnv: undefined })).toEqual({ origin: null });
+    expect(resolveCorsOrigin({ host: "::1", corsEnv: undefined })).toEqual({ origins: null });
   });
 
   it("throws for non-loopback without DEFCON_CORS_ORIGIN", () => {
@@ -22,15 +22,33 @@ describe("resolveCorsOrigin", () => {
     expect(() => resolveCorsOrigin({ host: "192.168.1.5", corsEnv: "" })).toThrow("DEFCON_CORS_ORIGIN");
   });
 
-  it("returns origin for non-loopback with DEFCON_CORS_ORIGIN set", () => {
+  it("returns single origin as array for non-loopback with DEFCON_CORS_ORIGIN set", () => {
     expect(resolveCorsOrigin({ host: "0.0.0.0", corsEnv: "https://my-app.example.com" })).toEqual({
-      origin: "https://my-app.example.com",
+      origins: ["https://my-app.example.com"],
     });
   });
 
-  it("returns origin for loopback with DEFCON_CORS_ORIGIN set (explicit override)", () => {
+  it("returns single origin as array for loopback with DEFCON_CORS_ORIGIN set (explicit override)", () => {
     expect(resolveCorsOrigin({ host: "127.0.0.1", corsEnv: "https://my-app.example.com" })).toEqual({
-      origin: "https://my-app.example.com",
+      origins: ["https://my-app.example.com"],
     });
+  });
+
+  it("returns multiple origins as array for comma-separated DEFCON_CORS_ORIGIN", () => {
+    expect(
+      resolveCorsOrigin({ host: "0.0.0.0", corsEnv: "https://app.example.com,http://localhost:3000" }),
+    ).toEqual({ origins: ["https://app.example.com", "http://localhost:3000"] });
+  });
+
+  it("trims whitespace around comma-separated origins", () => {
+    expect(
+      resolveCorsOrigin({ host: "0.0.0.0", corsEnv: "https://app.example.com , http://localhost:3000" }),
+    ).toEqual({ origins: ["https://app.example.com", "http://localhost:3000"] });
+  });
+
+  it("throws if any origin in a comma-separated list is invalid", () => {
+    expect(() =>
+      resolveCorsOrigin({ host: "0.0.0.0", corsEnv: "https://valid.example.com,not-an-origin" }),
+    ).toThrow("not-an-origin");
   });
 });


### PR DESCRIPTION
### **User description**
## Summary
- `DEFCON_CORS_ORIGIN` now accepts a comma-separated list of origins (e.g. `http://localhost:3000,http://localhost:3001`)
- Each origin is individually validated — invalid entries throw with a clear error message
- Needed to support the NORAD dashboard (`localhost:3000`) alongside other clients without using a wildcard

## Changes
- `src/cors.ts`: parse comma-separated env var, validate each entry, return `origins: string[] | null`
- `src/api/server.ts`: `corsOrigin?: string` → `corsOrigins?: string[]`, use `.includes()` check
- `src/execution/cli.ts`: switch SSE CORS from string/regex pattern to `Set<string> | null`
- Tests updated to cover single origin (backward compat), multi-origin, whitespace trimming, and invalid entry rejection

## Test plan
- [ ] `npm run check` passes (biome + tsc)
- [ ] `npx vitest run tests/cors.test.ts tests/cors-integration.test.ts tests/api/server.test.ts` — 47/47 pass
- [ ] Single-origin env var still works (no regression)
- [ ] Comma-separated env var allows both origins, blocks others

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Support comma-separated origins in `DEFCON_CORS_ORIGIN` environment variable

- Parse and validate each origin individually with clear error messages

- Update CORS checking logic to use set membership instead of exact match

- Add comprehensive tests for single, multiple, and invalid origin scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DEFCON_CORS_ORIGIN env var"] -->|"comma-separated list"| B["resolveCorsOrigin parser"]
  B -->|"validate each entry"| C["origins: string[] array"]
  C -->|"pass to HTTP server"| D["corsOrigins parameter"]
  D -->|"set membership check"| E["CORS allow/deny decision"]
  F["SSE server"] -->|"Set&lt;string&gt; lookup"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cors.ts</strong><dd><code>Parse and validate comma-separated CORS origins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cors.ts

<ul><li>Parse comma-separated origins from <code>DEFCON_CORS_ORIGIN</code> environment <br>variable<br> <li> Validate each origin individually against URL pattern<br> <li> Return <code>origins: string[] | null</code> instead of single <code>origin: string | </code><br><code>null</code><br> <li> Update error messages to mention comma-separated format support</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/defcon/pull/121/files#diff-a1624121bc1fee18f8a5c2b2f907f01ba9c56a50068007e4c5da2911e91ea6df">+18/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.ts</strong><dd><code>Update HTTP server CORS origin checking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/api/server.ts

<ul><li>Change <code>corsOrigin?: string</code> parameter to <code>corsOrigins?: string[]</code><br> <li> Update CORS check from exact string match to <code>.includes()</code> set <br>membership<br> <li> Maintain backward compatibility with loopback default pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/defcon/pull/121/files#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cli.ts</strong><dd><code>Update CLI server CORS handling for multiple origins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/execution/cli.ts

<ul><li>Pass <code>corsOrigins</code> array to HTTP server instead of single <code>corsOrigin</code><br> <li> Replace regex/string pattern with <code>Set<string></code> for SSE CORS validation<br> <li> Simplify origin checking logic using set membership test</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/defcon/pull/121/files#diff-a54dc2dfdaac200897cd261ef0ca9686b3c7c4c9491a783fe94dbdcd4d0f7072">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cors.test.ts</strong><dd><code>Expand CORS unit tests for multi-origin support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/cors.test.ts

<ul><li>Update all assertions to expect <code>origins: string[] | null</code> instead of <br><code>origin</code><br> <li> Add test for comma-separated origins parsing<br> <li> Add test for whitespace trimming around commas<br> <li> Add test for invalid origin rejection in comma-separated list</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/defcon/pull/121/files#diff-60859a0083dc21941ba3173553e08205ec10686bec2561d07ff4b4bd5ab38dd6">+25/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cors-integration.test.ts</strong><dd><code>Update CORS integration tests for arrays</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/cors-integration.test.ts

<ul><li>Update existing test to verify single origin returns as array<br> <li> Add new test for comma-separated origins parsing<br> <li> Update assertions to check <code>origins</code> array instead of <code>origin</code> string</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/defcon/pull/121/files#diff-e95e301d7d76d3a1e3a27f798aa2a108ced8d38b5ad00c8fa94140ac95055bf1">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.test.ts</strong><dd><code>Update HTTP server test for array origins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/api/server.test.ts

<ul><li>Update test setup to use <code>corsOrigins</code> array instead of single <br><code>corsOrigin</code><br> <li> Maintain test coverage for explicit CORS origin validation</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/defcon/pull/121/files#diff-64db51906dd66d646cf3090a36d1a644f6a2216bb285f720e2022a6573174c73">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support multiple CORS origins by parsing comma-separated DEFCON_CORS_ORIGIN and update `HttpServerDeps.createHttpServer` and CLI SSE server to enforce list-based origin checks
> Switch CORS config from single `corsOrigin` to `corsOrigins: string[]`, update origin matching to list membership in API and SSE servers, and parse `DEFCON_CORS_ORIGIN` as a comma-separated list in [src/cors.ts](https://github.com/wopr-network/defcon/pull/121/files#diff-a1624121bc1fee18f8a5c2b2f907f01ba9c56a50068007e4c5da2911e91ea6df).
>
> #### 📍Where to Start
> Start with `resolveCorsOrigin` in [src/cors.ts](https://github.com/wopr-network/defcon/pull/121/files#diff-a1624121bc1fee18f8a5c2b2f907f01ba9c56a50068007e4c5da2911e91ea6df), then follow how `origins` feeds `corsOrigins` into `createHttpServer` in [src/api/server.ts](https://github.com/wopr-network/defcon/pull/121/files#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8) and the SSE setup in [src/execution/cli.ts](https://github.com/wopr-network/defcon/pull/121/files#diff-a54dc2dfdaac200897cd261ef0ca9686b3c7c4c9491a783fe94dbdcd4d0f7072).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0860338.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->