### PR TITLE
chore: deprecate provision-worktree, superseded by nuke containers (WOP-2014)

### DIFF
--- a/src/execution/cli.ts
+++ b/src/execution/cli.ts
@@ -536,9 +536,11 @@ program
   });
 
 // ─── provision-worktree ───
+// TODO(WOP-2014): Remove this subcommand once nuke containers are deployed and stable.
+// Nuke workers provision their own workspace inside the container, making this unnecessary.
 program
   .command("provision-worktree")
-  .description("Provision a git worktree and branch for an issue")
+  .description("[DEPRECATED] Provision a git worktree and branch for an issue (superseded by nuke containers)")
   .argument("<repo>", "GitHub repo (e.g. wopr-network/defcon)")
   .argument("<issue-key>", "Issue key (e.g. WOP-392)")
   .option("--base-path <path>", "Worktree base directory", join(homedir(), "worktrees"))

--- a/src/execution/provision-worktree.ts
+++ b/src/execution/provision-worktree.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated provision-worktree is superseded by nuke containerized workers (WOP-2014).
+ * Nuke containers provision their own workspace inside the container.
+ * TODO: remove this file once nuke is deployed and stable.
+ */
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";


### PR DESCRIPTION
### **User description**
## Summary
Closes WOP-2014 (defcon prep component)

- Adds @deprecated JSDoc notice to provision-worktree.ts pointing to nuke (WOP-2014)
- Marks the provision-worktree CLI subcommand as [DEPRECATED] with a TODO to remove when nuke is stable
- Does not remove any code — full removal is deferred until nuke containers are deployed

## Test plan
- [ ] npm run check passes (biome + tsc)

Generated with Claude Code


___

### **PR Type**
Enhancement


___

### **Description**
- Adds deprecation notices to provision-worktree module and CLI command

- Marks feature as superseded by nuke containerized workers

- Defers code removal until nuke deployment and stability

- Includes TODO comments for future cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["provision-worktree module"] -->|"add @deprecated JSDoc"| B["Marked deprecated"]
  C["CLI subcommand"] -->|"add [DEPRECATED] label"| D["Marked deprecated"]
  B -->|"TODO: remove when stable"| E["Nuke containers"]
  D -->|"TODO: remove when stable"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.ts</strong><dd><code>Mark CLI subcommand as deprecated with TODO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/execution/cli.ts

<ul><li>Adds TODO comment referencing WOP-2014 for future removal<br> <li> Updates command description to include [DEPRECATED] label<br> <li> Clarifies that nuke containers supersede this functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/defcon/pull/137/files#diff-a54dc2dfdaac200897cd261ef0ca9686b3c7c4c9491a783fe94dbdcd4d0f7072">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>provision-worktree.ts</strong><dd><code>Add deprecation JSDoc notice to module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/execution/provision-worktree.ts

<ul><li>Adds JSDoc @deprecated notice at file header<br> <li> References WOP-2014 and nuke containerized workers<br> <li> Includes TODO comment for removal when nuke is stable</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/defcon/pull/137/files#diff-14e770d95e6ed3e5b5a755b30f22e249342d7c2af349a82a3bfe14df172066ff">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deprecate `provision-worktree` CLI subcommand superseded by nuke containers
> Adds a deprecation notice to the `provision-worktree` subcommand description in [cli.ts](https://github.com/wopr-network/defcon/pull/137/files#diff-a54dc2dfdaac200897cd261ef0ca9686b3c7c4c9491a783fe94dbdcd4d0f7072) and a JSDoc deprecation comment to [provision-worktree.ts](https://github.com/wopr-network/defcon/pull/137/files#diff-14e770d95e6ed3e5b5a755b30f22e249342d7c2af349a82a3bfe14df172066ff). No executable logic is changed; both files include TODO comments to remove once nuke containers are stable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90a16e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notices for the provision-worktree command to inform users of planned removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->