### PR TITLE
fix: emit entity.artifacts_updated domain event and replay handler

### DIFF
--- a/src/repositories/event-sourced/entity.repo.ts
+++ b/src/repositories/event-sourced/entity.repo.ts
@@ -67,7 +67,8 @@ export class EventSourcedEntityRepository implements IEntityRepository {
   }
 
   async updateArtifacts(id: string, artifacts: Partial<Artifacts>): Promise<void> {
-    return this.mutable.updateArtifacts(id, artifacts);
+    await this.mutable.updateArtifacts(id, artifacts);
+    await this.domainEvents.append("entity.artifacts_updated", id, artifacts as Record<string, unknown>);
   }
 
   async removeArtifactKeys(id: string, keys: string[]): Promise<void> {

--- a/src/repositories/event-sourced/replay.ts
+++ b/src/repositories/event-sourced/replay.ts
@@ -59,6 +59,13 @@ export function replayEntity(snapshot: Entity | null, events: DomainEvent[], ent
         state.updatedAt = new Date(event.emittedAt);
         break;
       }
+      case "entity.artifacts_updated": {
+        if (!state) break;
+        const p = event.payload as Record<string, unknown>;
+        state.artifacts = { ...(state.artifacts ?? {}), ...p };
+        state.updatedAt = new Date(event.emittedAt);
+        break;
+      }
       case "entity.artifacts_removed": {
         if (!state) break;
         const p = event.payload as Record<string, unknown>;


### PR DESCRIPTION
### **User description**
## Summary

- `EventSourcedEntityRepository.updateArtifacts` now appends an `entity.artifacts_updated` domain event after the mutable DB write, so artifact updates are visible during event-sourced entity replay
- Added `entity.artifacts_updated` case to `replayEntity` in `replay.ts` that merges the event payload into `entity.artifacts`
- Fixes CodeRabbit critical finding on PR #149: artifact updates written via `updateArtifacts` (e.g. before gate evaluation in `engine.ts`) were invisible when `get()` replayed the entity from events

## Test plan
- All 993 tests passing
- Pattern matches existing `entity.artifacts_removed` / `removeArtifactKeys` implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Emit `entity.artifacts_updated` domain event after artifact writes

- Add replay handler to merge artifact updates into entity state

- Ensures artifact updates visible during event-sourced entity replay

- Fixes artifact visibility issue in gate evaluation flow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  updateArtifacts["updateArtifacts called"]
  mutableWrite["Write to mutable DB"]
  emitEvent["Emit entity.artifacts_updated event"]
  replay["Replay entity from events"]
  mergeArtifacts["Merge artifacts into state"]
  
  updateArtifacts --> mutableWrite
  mutableWrite --> emitEvent
  replay --> mergeArtifacts
  emitEvent -.-> replay
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entity.repo.ts</strong><dd><code>Emit artifacts_updated domain event after write</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/repositories/event-sourced/entity.repo.ts

<ul><li>Changed <code>updateArtifacts</code> to await mutable DB write before appending <br>event<br> <li> Added domain event emission for <code>entity.artifacts_updated</code> with artifact <br>payload<br> <li> Ensures artifact updates are captured in event stream for replay</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/silo/pull/151/files#diff-a4e41f7dff098a0390c51429e44c48805f10ac95b74580e6ea27ea9904d3c746">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>replay.ts</strong><dd><code>Add replay handler for artifacts_updated event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/repositories/event-sourced/replay.ts

<ul><li>Added new case handler for <code>entity.artifacts_updated</code> event<br> <li> Merges event payload into <code>state.artifacts</code> using spread operator<br> <li> Updates <code>state.updatedAt</code> timestamp to event emission time<br> <li> Follows same pattern as existing <code>entity.artifacts_removed</code> handler</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/silo/pull/151/files#diff-39d4f7169229f6c94254677d04cbc671cf1cc5923497708e404f1d77024bb2db">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit and replay `entity.artifacts_updated` domain event in event-sourced entity repository
> - [entity.repo.ts](https://github.com/wopr-network/silo/pull/151/files#diff-a4e41f7dff098a0390c51429e44c48805f10ac95b74580e6ea27ea9904d3c746): `updateArtifacts` now awaits the mutable store update and then appends an `entity.artifacts_updated` domain event with the artifacts payload.
> - [replay.ts](https://github.com/wopr-network/silo/pull/151/files#diff-39d4f7169229f6c94254677d04cbc671cf1cc5923497708e404f1d77024bb2db): `replayEntity` now handles `entity.artifacts_updated` by merging the event payload into `state.artifacts` (initializing if null) and updating `updatedAt`.
> - Behavioral Change: artifact updates now fail if either the mutable write or the event append fails, and replayed entity state will include artifact changes from historical events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 014d950.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->