### PR TITLE
fix: auto-claim race, model_tier wire type, gate log privacy

### DIFF
--- a/src/api/wire-types.ts
+++ b/src/api/wire-types.ts
@@ -26,6 +26,8 @@ export type ReportResponse =
       gates_passed?: string[];
       prompt: string | null;
       context: Record<string, unknown> | null;
+      model_tier?: string;
+      agent_role?: string;
     }
   | {
       next_action: "waiting";

--- a/src/engine/direct-flow-engine.ts
+++ b/src/engine/direct-flow-engine.ts
@@ -225,25 +225,33 @@ export class DirectFlowEngine implements IFlowEngine {
     if (nextAction === "continue") {
       // Auto-claim the next invocation for the same worker so the RunLoop
       // can report against it without a separate claim round-trip.
-      // If claim fails, fall back to waiting — the RunLoop will re-claim.
-      let claimed = false;
+      // When workerId is absent, skip auto-claim and fall through to the
+      // continue response — the caller will re-claim on its own.
       if (result.invocationId && workerId) {
+        let claimed = false;
         try {
           const claimResult = await this.invocations.claim(result.invocationId, workerId);
           claimed = claimResult !== null;
         } catch (err) {
           this.logger.warn(`[direct-engine] auto-claim failed for invocation ${result.invocationId}`, err);
         }
-      }
-
-      if (!claimed) {
-        return {
-          next_action: "completed",
-          new_state: result.newState ?? "",
-          gates_passed: result.gatesPassed,
-          prompt: null,
-          context: null,
-        };
+        if (!claimed) {
+          // Claim lost to a race — release the slot so the RunLoop exits its
+          // inner loop and re-claims via claimWork, rather than looping on the
+          // old prompt and hitting "no active invocation" on the next report.
+          this.logger.warn(`[direct-engine] auto-claim race — releasing slot`, {
+            entityId,
+            invocationId: result.invocationId,
+            newState: result.newState,
+          });
+          return {
+            next_action: "completed",
+            new_state: result.newState ?? "",
+            gates_passed: result.gatesPassed,
+            prompt: null,
+            context: null,
+          };
+        }
       }
 
       // Look up model_tier and agent_role for the new state using the entity's
@@ -259,8 +267,22 @@ export class DirectFlowEngine implements IFlowEngine {
             if (newStateDef) {
               next_model_tier = newStateDef.modelTier ?? undefined;
               next_agent_role = newStateDef.agentRole ?? undefined;
+            } else {
+              this.logger.warn(`[direct-engine] state "${result.newState}" not found in flow version`, {
+                entityId,
+                flowId: entity.flowId,
+                flowVersion: entity.flowVersion,
+              });
             }
+          } else {
+            this.logger.warn(`[direct-engine] flow version not found for model_tier lookup`, {
+              entityId,
+              flowId: entity.flowId,
+              flowVersion: entity.flowVersion,
+            });
           }
+        } else {
+          this.logger.warn(`[direct-engine] entity not found for model_tier lookup`, { entityId });
         }
       }
       return {

--- a/src/engine/gate-evaluator.ts
+++ b/src/engine/gate-evaluator.ts
@@ -169,9 +169,12 @@ export async function evaluateGate(
       exitCode: result.exitCode,
       timedOut: result.timedOut,
       stdoutLineCount: stdoutLines.length,
-      lastLine: lastLine ?? "(empty)",
       stdoutLength: result.stdout.length,
       outputLength: result.output.length,
+    });
+    logger.debug(`[gate] "${gate.name}" last stdout line`, {
+      entityId: entity.id,
+      lastLine: lastLine ?? "(empty)",
     });
 
     // Parse structured JSON outcome from the last non-empty stdout line.
@@ -184,8 +187,11 @@ export async function evaluateGate(
           logger.info(`[gate] "${gate.name}" parsed outcome: ${String(parsed.outcome)}`, {
             entityId: entity.id,
             outcome: parsed.outcome,
-            message: parsed.message ?? "(none)",
             passed,
+          });
+          logger.debug(`[gate] "${gate.name}" outcome message`, {
+            entityId: entity.id,
+            message: parsed.message ?? "(none)",
           });
           const outcomeResult = {
             passed,


### PR DESCRIPTION
### **User description**
Replaces #149 (conflicted with multi-repo engine changes from #145–#148). Clean rebase off current main with only the net-new fixes.

## Changes

- **DirectFlowEngine**: auto-claim guard moved inside the `workerId` block — callers without `workerId` now get a correct `continue` response instead of `check_back`; on race failure returns `completed` to release the slot cleanly rather than looping on stale prompt
- **DirectFlowEngine**: warn logs added when entity/flow/state lookup fails during `model_tier` resolution on the continue path
- **wire-types**: `model_tier?` and `agent_role?` added to `continue` `ReportResponse` so run-loop can update routing on state transitions  
- **gate-evaluator**: `lastLine` and outcome `message` moved to `debug` level to avoid leaking gate script content in production info logs

## Test plan
- 993 tests passing (79 files)
- Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Move auto-claim guard inside `workerId` block to fix race condition

- Return `completed` on claim race to release slot cleanly

- Add `model_tier?` and `agent_role?` fields to continue response

- Add warn logs for entity/flow/state lookup failures during routing

- Move gate script content logs to debug level for privacy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Auto-claim logic"] -->|"Move inside workerId block"| B["Correct continue response"]
  A -->|"On race failure"| C["Return completed"]
  D["Continue response"] -->|"Add model_tier & agent_role"| E["Enable routing updates"]
  F["Gate evaluator logs"] -->|"Move to debug level"| G["Prevent script leaks"]
  H["Model tier lookup"] -->|"Add warn logs"| I["Better debugging"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wire-types.ts</strong><dd><code>Add routing fields to continue response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/api/wire-types.ts

<ul><li>Added optional <code>model_tier?</code> field to continue response<br> <li> Added optional <code>agent_role?</code> field to continue response<br> <li> Enables run-loop to update routing on state transitions</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/silo/pull/152/files#diff-3daf581caddfa5575f33227ff2e3ce0d014eb40046dc314ec5719e819f63212d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>direct-flow-engine.ts</strong><dd><code>Fix auto-claim race and add routing lookup logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/engine/direct-flow-engine.ts

<ul><li>Moved auto-claim guard inside <code>workerId</code> conditional block<br> <li> Changed race failure behavior from <code>waiting</code> to <code>completed</code> response<br> <li> Added warn logs for entity, flow, and state lookup failures<br> <li> Improved logging with context details for debugging</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/silo/pull/152/files#diff-5a37a0943ab09985f4477a42e41a7e8f59cb45188b804b8746184331a5ad44e5">+34/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gate-evaluator.ts</strong><dd><code>Move gate script content to debug logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/engine/gate-evaluator.ts

<ul><li>Moved <code>lastLine</code> field from info to debug log level<br> <li> Moved outcome <code>message</code> field from info to debug log level<br> <li> Prevents leaking gate script content in production logs<br> <li> Maintains outcome parsing info logs without sensitive data</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/silo/pull/152/files#diff-2fbba9489ac39de7e98310890772c5fbfce792a6bef32e5a728095adb709c937">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix auto-claim race condition and add `model_tier`/`agent_role` to continue responses
> - Fixes a race condition in `DirectFlowEngine.claim`: when auto-claim fails, logs a warning and returns a `completed` response to release the slot instead of leaving it stuck.
> - Skips auto-claim entirely when `workerId` is absent, proceeding directly to the `continue` response.
> - Adds `model_tier` and `agent_role` fields to `continue` responses, resolved from the entity's pinned flow version and next state.
> - Moves last stdout line and outcome message from info-level to debug-level logs in `gate-evaluator.evaluateGate` to reduce log verbosity.
> - Behavioral Change: auto-claim failures now return `completed` rather than `continue`, which releases the worker slot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe2852b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->