### PR TITLE
fix: remove redundant 405 guard, add auto-merge error logging in github.ts

### DIFF
--- a/src/integrations/adapters/github.ts
+++ b/src/integrations/adapters/github.ts
@@ -233,11 +233,15 @@ export class GitHubVcsAdapter implements IVcsAdapter {
           body: JSON.stringify({ query: enableMutation, variables: { id: prNodeId } }),
           signal,
         });
+        const enableBody = await enableRes.text();
         if (!enableRes.ok) {
-          console.error(
-            `[github] enablePullRequestAutoMerge mutation failed — status ${enableRes.status}`,
-            await enableRes.text(),
-          );
+          console.error(`[github] enablePullRequestAutoMerge mutation failed — status ${enableRes.status}`, enableBody);
+        } else {
+          // GitHub GraphQL always returns HTTP 200; check for application-level errors
+          const enableData = JSON.parse(enableBody) as { errors?: { message: string }[] };
+          if (enableData.errors?.length) {
+            console.error(`[github] enablePullRequestAutoMerge mutation returned GraphQL errors`, enableData.errors);
+          }
         }
       }
     }


### PR DESCRIPTION
### **User description**
## Summary

Addresses review findings on `mergePr` in `src/integrations/adapters/github.ts`:

- **Remove redundant guard**: after `if (mergeRes.status !== 405) throw`, we are already in the 405 path — the inner `if (mergeRes.status === 405)` was dead code; unwrapped the block
- **Log nodeRes failure**: when the GraphQL fetch for the PR node id returns a non-ok status, log the HTTP status and response body via `console.error`
- **Log missing prNodeId**: when the GraphQL response omits the PR node id, log `owner/repo#prNumber` so operators can trace the stuck merge
- **Log mutation failure**: capture the `enablePullRequestAutoMerge` mutation response; log status and body if non-ok

## Verification

- Redundant `if (mergeRes.status === 405)` — ❌ confirmed present → removed
- `nodeRes.ok` false path silent — ❌ confirmed → now logs status + body
- `prNodeId` missing path silent — ❌ confirmed → now logs owner/repo/prNumber
- Mutation response unchecked — ❌ confirmed → now captured and logged on failure

## Test plan
- [x] `pnpm lint` — 0 warnings/errors
- [x] `pnpm format` — no fixes needed
- [x] `pnpm build` — tsc clean
- [x] `pnpm test` — 993 passed, 12 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove redundant 405 status check after early throw guard

- Add error logging for GraphQL node fetch failures

- Add error logging when PR node ID is missing from response

- Add error logging for auto-merge mutation failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Merge attempt"] --> B{"Status 405?"}
  B -->|No| C["Throw error"]
  B -->|Yes| D["Fetch PR node ID"]
  D --> E{"Fetch OK?"}
  E -->|No| F["Log nodeRes error"]
  E -->|Yes| G{"Node ID found?"}
  G -->|No| H["Log missing node ID"]
  G -->|Yes| I["Execute auto-merge mutation"]
  I --> J{"Mutation OK?"}
  J -->|No| K["Log mutation error"]
  J -->|Yes| L["Success"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.ts</strong><dd><code>Add error logging to auto-merge GraphQL operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/integrations/adapters/github.ts

<ul><li>Removed redundant <code>if (mergeRes.status === 405)</code> guard that was dead <br>code after the early throw<br> <li> Added <code>console.error</code> logging when GraphQL node fetch returns non-ok <br>status with HTTP status and response body<br> <li> Added <code>console.error</code> logging when PR node ID is missing from GraphQL <br>response, including owner/repo#prNumber for diagnosis<br> <li> Captured <code>enablePullRequestAutoMerge</code> mutation response and added error <br>logging on failure with status and body</ul>


</details>


  </td>
  <td><a href="https://github.com/wopr-network/silo/pull/155/files#diff-7a48d9eaf00f1658a5056e2290f9750f23478bcf67336c31365710df5a97c033">+39/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add error logging to auto-merge GraphQL path in `GitHubVcsAdapter`
> Adds `console.error` logging to the auto-merge enablement path in [github.ts](https://github.com/wopr-network/silo/pull/155/files#diff-7a48d9eaf00f1658a5056e2290f9750f23478bcf67336c31365710df5a97c033) so failures are visible without changing control flow or return values. Logs are emitted when the GraphQL node lookup fails, when the PR node ID is missing, when the mutation HTTP response is not ok, or when the mutation returns GraphQL-level errors on an HTTP 200. Also removes a now-redundant 405 guard that was already enforced by the surrounding status check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2fa6f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->