### PR TITLE
feat: add RADAR routes to silo — pool, workers, activity, sources, events

### DIFF
--- a/src/api/hono-server.ts
+++ b/src/api/hono-server.ts
@@ -17,6 +17,9 @@ import type { McpServerDeps } from "../execution/mcp-server.js";
 import { callToolHandler } from "../execution/mcp-server.js";
 import type { Logger } from "../logger.js";
 import { consoleLogger } from "../logger.js";
+import type { Pool } from "../pool/index.js";
+import type { IEntityActivityRepo } from "../radar-db/repos/i-entity-activity-repo.js";
+import type { EventLogRepo, IWorkerRepo, SourceRepo, WatchRepo } from "../radar-db/types.js";
 import { createScopedRepos } from "../repositories/scoped-repos.js";
 import { UI_HTML } from "../ui/index.html.js";
 
@@ -124,6 +127,18 @@ export interface HonoServerDeps {
   logger?: Logger;
   enableUi?: boolean;
   sseAdapter?: HonoSseAdapter;
+  /** Worker pool — exposes slot/capacity data via /api/pool/slots */
+  pool?: Pool;
+  /** Worker registry — exposes registered workers via /api/workers */
+  workerRepo?: IWorkerRepo;
+  /** Entity activity log — exposes per-entity activity via /api/entities/:id/activity */
+  activityRepo?: IEntityActivityRepo;
+  /** Source registry — exposes sources via /api/sources */
+  sourceRepo?: SourceRepo;
+  /** Watch registry — exposes watches via /api/sources/:id/watches */
+  watchRepo?: WatchRepo;
+  /** Event log — exposes ingest events via /api/events */
+  eventLogRepo?: EventLogRepo;
 }
 
 // ─── Build the Hono app ───
@@ -397,6 +412,55 @@ export function createHonoApp(deps: HonoServerDeps): Hono {
     const result = await callToolHandler(await getMcpDeps(c), "query.entities", args);
     const { status, body: resBody } = mcpResultToResponse(result);
     return c.json(resBody as Record<string, unknown>, status as 200);
+  });
+
+  // ─── Entity activity (RADAR) ───
+  app.get("/api/entities/:id/activity", requireAdminAuth(), async (c) => {
+    if (!deps.activityRepo) return c.json({ error: "Activity repo not configured" }, 503);
+    const entityId = c.req.param("id") ?? "";
+    const sinceStr = c.req.query("since");
+    const since = sinceStr !== undefined ? parseInt(sinceStr, 10) : 0;
+    const items = await deps.activityRepo.getByEntity(entityId, since || undefined);
+    const nextSeq = items.length > 0 ? (items[items.length - 1]?.seq ?? 0) + 1 : since;
+    return c.json({ items, nextSeq });
+  });
+
+  // ─── Pool slots (RADAR) ───
+  app.get("/api/pool/slots", requireAdminAuth(), async (c) => {
+    if (!deps.pool) return c.json({ slots: [], available: 0, capacity: 0 });
+    return c.json({
+      slots: deps.pool.activeSlots(),
+      available: deps.pool.availableSlots(),
+      capacity: deps.pool.getCapacity(),
+    });
+  });
+
+  // ─── Workers (RADAR) ───
+  app.get("/api/workers", requireAdminAuth(), async (c) => {
+    if (!deps.workerRepo) return c.json([]);
+    const workers = await deps.workerRepo.list();
+    return c.json(workers);
+  });
+
+  // ─── Sources (RADAR) ───
+  app.get("/api/sources", requireAdminAuth(), async (c) => {
+    if (!deps.sourceRepo) return c.json([]);
+    return c.json(await deps.sourceRepo.findAll());
+  });
+
+  app.get("/api/sources/:id/watches", requireAdminAuth(), async (c) => {
+    if (!deps.watchRepo) return c.json([]);
+    return c.json(await deps.watchRepo.findBySourceId(c.req.param("id") ?? ""));
+  });
+
+  // ─── Event log (RADAR) ───
+  app.get("/api/events", requireAdminAuth(), async (c) => {
+    if (!deps.eventLogRepo) return c.json([]);
+    const limitStr = c.req.query("limit");
+    const offsetStr = c.req.query("offset");
+    const limit = limitStr ? parseInt(limitStr, 10) : 50;
+    const offset = offsetStr ? parseInt(offsetStr, 10) : 0;
+    return c.json(await deps.eventLogRepo.findAll({ limit, offset }));
   });
 
   // ─── Flow definitions ───


### PR DESCRIPTION
## Summary

- Adds pool/worker/activity/source/event HTTP routes to the unified silo Hono server, eliminating the need for NORAD to talk to a separate RADAR service
- All new routes are optional (deps are nil-safe) and require admin auth

## Routes added

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/pool/slots` | Active slots + capacity |
| GET | `/api/workers` | Registered worker list |
| GET | `/api/entities/:id/activity` | Per-entity activity log (`?since=N`) |
| GET | `/api/sources` | Source registry |
| GET | `/api/sources/:id/watches` | Watches for a source |
| GET | `/api/events` | Ingest event log (`?limit&offset`) |

## HonoServerDeps additions

```typescript
pool?: Pool;
workerRepo?: IWorkerRepo;
activityRepo?: IEntityActivityRepo;
sourceRepo?: SourceRepo;
watchRepo?: WatchRepo;
eventLogRepo?: EventLogRepo;
```

All optional — existing deployments without these deps get empty/503 responses gracefully.

## Test plan

- [x] `pnpm lint && pnpm format && pnpm build && pnpm test` all pass (993 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wopr-network/silo/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Add optional RADAR-related HTTP endpoints to the unified Hono API server to expose pool, workers, activity, sources, watches, and event logs behind admin authentication.

New Features:
- Expose entity activity via /api/entities/:id/activity with optional since filtering.
- Expose worker pool slot and capacity information via /api/pool/slots.
- Expose registered workers via /api/workers.
- Expose source registry and per-source watches via /api/sources and /api/sources/:id/watches.
- Expose ingest event log with pagination via /api/events.

Enhancements:
- Extend HonoServerDeps with optional RADAR-related dependencies so existing deployments can adopt the new endpoints without breaking changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RADAR admin routes for pool, workers, activity, sources, and events to silo
> Adds six new admin-authenticated GET endpoints to [hono-server.ts](https://github.com/wopr-network/silo/pull/156/files#diff-6df2a1ab9324f5b6645c929a7b3503dc1636fa476eef400fbb67b16ae041b1af) under the RADAR namespace, wired through optional dependencies in `HonoServerDeps`:
> - `GET /api/entities/:id/activity` — returns paginated entity activity with sequence tracking; returns 503 if `activityRepo` is absent
> - `GET /api/pool/slots` — returns active slots, available slots, and capacity from the worker pool; returns zeros if `pool` is absent
> - `GET /api/workers` — lists registered workers via `workerRepo.list()`
> - `GET /api/sources` and `GET /api/sources/:id/watches` — lists all sources or watches for a given source
> - `GET /api/events` — paginates event logs with configurable `limit` (default 50) and `offset` (default 0)
> - All routes return empty arrays or zero values as fallbacks when the corresponding dependency is not configured, except `/api/entities/:id/activity` which returns a 503
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2c456d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced RADAR API endpoints for retrieving entity activity, pool information, worker data, sources, source watches, and event logs
  * Admin authentication required for all new endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->