### PR TITLE
feat: remove shell execution from onEnter/onExit (WOP-2160)

### DIFF
--- a/src/config/zod-schemas.ts
+++ b/src/config/zod-schemas.ts
@@ -29,24 +29,14 @@ export const FlowDefinitionSchema = z.object({
 });
 
 export const OnEnterSchema = z.object({
-  command: z
-    .string()
-    .min(1)
-    .refine((val) => validateTemplate(val), {
-      message: "onEnter command contains disallowed Handlebars expressions",
-    }),
+  op: z.enum(PRIMITIVE_OPS),
+  params: z.record(z.string(), z.unknown()).optional(),
   artifacts: z.array(z.string().min(1)).min(1),
-  timeout_ms: z.number().int().min(0).optional().default(30000),
 });
 
 export const OnExitSchema = z.object({
-  command: z
-    .string()
-    .min(1)
-    .refine((val) => validateTemplate(val), {
-      message: "onExit command contains disallowed Handlebars expressions",
-    }),
-  timeout_ms: z.number().int().min(1).optional().default(30000),
+  op: z.enum(PRIMITIVE_OPS),
+  params: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const StateDefinitionSchema = z.object({

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -91,6 +91,8 @@ export interface EngineDeps {
   domainEvents?: IDomainEventRepository;
   /** Optional integration repository. When provided, primitive gate ops and onEnter ops are resolved through the AdapterRegistry. */
   integrationRepo?: IIntegrationRepository;
+  /** Optional pre-built AdapterRegistry. Takes precedence over integrationRepo when both are provided. */
+  adapterRegistry?: AdapterRegistry;
 }
 
 export class Engine {
@@ -122,7 +124,8 @@ export class Engine {
     this.withTransactionFn = deps.withTransaction ?? null;
     this.repoFactory = deps.repoFactory ?? null;
     this.domainEventRepo = deps.domainEvents ?? null;
-    this.adapterRegistry = deps.integrationRepo ? new AdapterRegistry(deps.integrationRepo) : null;
+    this.adapterRegistry =
+      deps.adapterRegistry ?? (deps.integrationRepo ? new AdapterRegistry(deps.integrationRepo) : null);
   }
 
   drainWorker(workerId: string): void {
@@ -269,7 +272,7 @@ export class Engine {
     // 4b. Execute onExit hook on the DEPARTING state (before transition)
     const departingStateDef = flow.states.find((s) => s.name === entity.state);
     if (departingStateDef?.onExit) {
-      const onExitResult = await executeOnExit(departingStateDef.onExit, entity);
+      const onExitResult = await executeOnExit(departingStateDef.onExit, entity, flow, this.adapterRegistry);
       if (onExitResult.error) {
         this.logger.warn(`[engine] onExit failed for entity ${entityId} state ${entity.state}: ${onExitResult.error}`);
         await emitter.emit({

--- a/src/engine/on-enter.ts
+++ b/src/engine/on-enter.ts
@@ -1,4 +1,3 @@
-import { execFile } from "node:child_process";
 import type { AdapterRegistry } from "../integrations/registry.js";
 import type { PrimitiveOp } from "../integrations/types.js";
 import type { Entity, Flow, IEntityRepository, OnEnterConfig } from "../repositories/interfaces.js";
@@ -25,117 +24,6 @@ export async function executeOnEnter(
     return { skipped: true, artifacts: null, error: null, timedOut: false };
   }
 
-  // Primitive op path — no shell, runs through the adapter registry
-  if (onEnter.op) {
-    return executePrimitiveOnEnter(onEnter, entity, entityRepo, flow, adapterRegistry);
-  }
-
-  // Render command via Handlebars
-  const hbs = getHandlebars();
-  let renderedCommand: string;
-  // Merge artifact refs into entity.refs so onEnter command templates like
-  // {{entity.refs.github.repo}} resolve correctly for REST-created entities.
-  const artifactRefs =
-    entity.artifacts !== null &&
-    typeof entity.artifacts === "object" &&
-    "refs" in entity.artifacts &&
-    entity.artifacts.refs !== null &&
-    typeof entity.artifacts.refs === "object"
-      ? (entity.artifacts.refs as Record<string, unknown>)
-      : {};
-  const entityForContext = { ...entity, refs: { ...artifactRefs, ...(entity.refs ?? {}) } };
-
-  try {
-    renderedCommand = hbs.compile(onEnter.command)({ entity: entityForContext });
-  } catch (err) {
-    const error = `onEnter template error: ${err instanceof Error ? err.message : String(err)}`;
-    await entityRepo.updateArtifacts(entity.id, {
-      onEnter_error: {
-        command: onEnter.command,
-        error,
-        failedAt: new Date().toISOString(),
-      },
-    });
-    return { skipped: false, artifacts: null, error, timedOut: false };
-  }
-
-  // Execute command
-  const timeoutMs = onEnter.timeout_ms ?? 30000;
-  const { exitCode, stdout, stderr, timedOut } = await runOnEnterCommand(renderedCommand, timeoutMs);
-
-  if (timedOut) {
-    const error = `onEnter command timed out after ${timeoutMs}ms`;
-    await entityRepo.updateArtifacts(entity.id, {
-      onEnter_error: {
-        command: renderedCommand,
-        error,
-        stderr,
-        failedAt: new Date().toISOString(),
-      },
-    });
-    return { skipped: false, artifacts: null, error, timedOut: true };
-  }
-
-  if (exitCode !== 0) {
-    const error = `onEnter command exited with code ${exitCode}: ${stderr || stdout}`;
-    await entityRepo.updateArtifacts(entity.id, {
-      onEnter_error: {
-        command: renderedCommand,
-        error,
-        failedAt: new Date().toISOString(),
-      },
-    });
-    return { skipped: false, artifacts: null, error, timedOut: false };
-  }
-
-  // Parse JSON stdout
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(stdout);
-  } catch {
-    const error = `onEnter stdout is not valid JSON: ${stdout.slice(0, 200)}`;
-    await entityRepo.updateArtifacts(entity.id, {
-      onEnter_error: {
-        command: renderedCommand,
-        error,
-        failedAt: new Date().toISOString(),
-      },
-    });
-    return { skipped: false, artifacts: null, error, timedOut: false };
-  }
-
-  // Extract named artifact keys
-  const missingKeys = onEnter.artifacts.filter((key) => parsed[key] === undefined);
-  if (missingKeys.length > 0) {
-    const error = `onEnter stdout missing expected artifact keys: ${missingKeys.join(", ")}`;
-    await entityRepo.updateArtifacts(entity.id, {
-      onEnter_error: {
-        command: renderedCommand,
-        error,
-        failedAt: new Date().toISOString(),
-      },
-    });
-    return { skipped: false, artifacts: null, error, timedOut: false };
-  }
-
-  const mergedArtifacts: Record<string, unknown> = {};
-  for (const key of onEnter.artifacts) {
-    mergedArtifacts[key] = parsed[key];
-  }
-
-  // Merge into entity
-  await entityRepo.updateArtifacts(entity.id, mergedArtifacts);
-
-  return { skipped: false, artifacts: mergedArtifacts, error: null, timedOut: false };
-}
-
-async function executePrimitiveOnEnter(
-  onEnter: OnEnterConfig,
-  entity: Entity,
-  entityRepo: IEntityRepository,
-  flow?: Flow | null,
-  adapterRegistry?: AdapterRegistry | null,
-): Promise<OnEnterResult> {
   const op = onEnter.op as PrimitiveOp;
 
   if (!adapterRegistry) {
@@ -204,21 +92,4 @@ async function executePrimitiveOnEnter(
 
   await entityRepo.updateArtifacts(entity.id, mergedArtifacts);
   return { skipped: false, artifacts: mergedArtifacts, error: null, timedOut: false };
-}
-
-function runOnEnterCommand(
-  command: string,
-  timeoutMs: number,
-): Promise<{ exitCode: number; stdout: string; stderr: string; timedOut: boolean }> {
-  return new Promise((resolve) => {
-    const child = execFile("/bin/sh", ["-c", command], { timeout: timeoutMs }, (error, stdout, stderr) => {
-      const timedOut = error !== null && child.killed === true;
-      resolve({
-        exitCode: error ? ((error as NodeJS.ErrnoException & { code?: number }).code ?? 1) : 0,
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-        timedOut,
-      });
-    });
-  });
 }

--- a/src/engine/on-exit.ts
+++ b/src/engine/on-exit.ts
@@ -1,5 +1,6 @@
-import { type ExecFileException, execFile } from "node:child_process";
-import type { Entity, OnExitConfig } from "../repositories/interfaces.js";
+import type { AdapterRegistry } from "../integrations/registry.js";
+import type { PrimitiveOp } from "../integrations/types.js";
+import type { Entity, Flow, OnExitConfig } from "../repositories/interfaces.js";
 import { getHandlebars } from "./handlebars.js";
 
 export interface OnExitResult {
@@ -7,11 +8,26 @@ export interface OnExitResult {
   timedOut: boolean;
 }
 
-export async function executeOnExit(onExit: OnExitConfig, entity: Entity): Promise<OnExitResult> {
-  const hbs = getHandlebars();
-  let renderedCommand: string;
+export async function executeOnExit(
+  onExit: OnExitConfig,
+  entity: Entity,
+  flow?: Flow | null,
+  adapterRegistry?: AdapterRegistry | null,
+): Promise<OnExitResult> {
+  const op = onExit.op as PrimitiveOp;
 
-  // Merge artifact refs into entity.refs (same pattern as on-enter.ts)
+  if (!adapterRegistry) {
+    return { error: "AdapterRegistry not available for primitive onExit op", timedOut: false };
+  }
+
+  const opCategory = op.split(".")[0];
+  const integrationId = opCategory === "issue_tracker" ? flow?.issueTrackerIntegrationId : flow?.vcsIntegrationId;
+
+  if (!integrationId) {
+    return { error: `Flow has no ${opCategory} integration configured`, timedOut: false };
+  }
+
+  const hbs = getHandlebars();
   const artifactRefs =
     entity.artifacts !== null &&
     typeof entity.artifacts === "object" &&
@@ -22,41 +38,30 @@ export async function executeOnExit(onExit: OnExitConfig, entity: Entity): Promi
       : {};
   const entityForContext = { ...entity, refs: { ...artifactRefs, ...(entity.refs ?? {}) } };
 
+  let renderedParams: Record<string, unknown>;
   try {
-    renderedCommand = hbs.compile(onExit.command)({ entity: entityForContext });
+    const rawParams = onExit.params ?? {};
+    renderedParams = Object.fromEntries(
+      Object.entries(rawParams).map(([k, v]) => [
+        k,
+        typeof v === "string" ? hbs.compile(v)({ entity: entityForContext }) : v,
+      ]),
+    );
   } catch (err) {
-    const error = `onExit template error: ${err instanceof Error ? err.message : String(err)}`;
-    return { error, timedOut: false };
+    return {
+      error: `Primitive onExit template error: ${err instanceof Error ? err.message : String(err)}`,
+      timedOut: false,
+    };
   }
 
-  const timeoutMs = onExit.timeout_ms ?? 30000;
-  const { exitCode, stdout, stderr, timedOut } = await runCommand(renderedCommand, timeoutMs);
-
-  if (timedOut) {
-    return { error: `onExit command timed out after ${timeoutMs}ms`, timedOut: true };
-  }
-
-  if (exitCode !== 0) {
-    return { error: `onExit command exited with code ${exitCode}: ${stderr || stdout}`, timedOut: false };
+  try {
+    await adapterRegistry.execute(integrationId, op, renderedParams);
+  } catch (err) {
+    return {
+      error: `Primitive onExit op failed: ${err instanceof Error ? err.message : String(err)}`,
+      timedOut: false,
+    };
   }
 
   return { error: null, timedOut: false };
-}
-
-function runCommand(
-  command: string,
-  timeoutMs: number,
-): Promise<{ exitCode: number; stdout: string; stderr: string; timedOut: boolean }> {
-  return new Promise((resolve) => {
-    execFile("/bin/sh", ["-c", command], { timeout: timeoutMs }, (error, stdout, stderr) => {
-      const execErr = error as ExecFileException | null;
-      const timedOut = execErr !== null && execErr.killed === true;
-      resolve({
-        exitCode: execErr ? (typeof execErr.code === "number" ? execErr.code : 1) : 0,
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-        timedOut,
-      });
-    });
-  });
 }

--- a/src/repositories/interfaces.ts
+++ b/src/repositories/interfaces.ts
@@ -6,22 +6,21 @@ export type Refs = Record<string, { adapter: string; id: string; [key: string]: 
 /** Freeform key-value artifact bag */
 export type Artifacts = Record<string, unknown>;
 
-/** Configuration for running a command when an entity enters a state */
+/** Configuration for running a primitive op when an entity enters a state */
 export interface OnEnterConfig {
-  /** Shell command (legacy). Mutually exclusive with `op`. */
-  command?: string;
-  /** Primitive op identifier, e.g. "issue_tracker.fetch_comment". Mutually exclusive with `command`. */
-  op?: string;
-  /** Handlebars-rendered params for the primitive op. */
+  /** Primitive op identifier, e.g. "vcs.provision_worktree" or "issue_tracker.fetch_spec". */
+  op: string;
+  /** Handlebars-rendered params passed to the adapter op. */
   params?: Record<string, unknown>;
   artifacts: string[];
-  timeout_ms?: number;
 }
 
-/** Configuration for running a cleanup command when an entity exits a state */
+/** Configuration for running a primitive op when an entity exits a state */
 export interface OnExitConfig {
-  command: string;
-  timeout_ms?: number;
+  /** Primitive op identifier, e.g. "vcs.cleanup_worktree". */
+  op: string;
+  /** Handlebars-rendered params passed to the adapter op. */
+  params?: Record<string, unknown>;
 }
 
 /** Invocation execution mode */

--- a/tests/on-enter.test.ts
+++ b/tests/on-enter.test.ts
@@ -6,6 +6,8 @@ import { DrizzleEntityRepository } from "../src/repositories/drizzle/entity.repo
 import { DrizzleFlowRepository } from "../src/repositories/drizzle/flow.repo.js";
 import { DrizzleGateRepository } from "../src/repositories/drizzle/gate.repo.js";
 import { DrizzleInvocationRepository } from "../src/repositories/drizzle/invocation.repo.js";
+import { DrizzleIntegrationRepository } from "../src/integrations/repo.js";
+import type { AdapterRegistry } from "../src/integrations/registry.js";
 import type { Entity, IEntityRepository, IEventBusAdapter, ITransitionLogRepository, OnEnterConfig } from "../src/repositories/interfaces.js";
 
 const TEST_TENANT = "test-tenant";
@@ -52,31 +54,48 @@ function makeEntityRepo(): IEntityRepository & { updatedArtifacts: Record<string
   return repo as unknown as IEntityRepository & { updatedArtifacts: Record<string, unknown>[] };
 }
 
+function makeFlow(overrides?: object) {
+  return {
+    id: "flow-1",
+    name: "test-flow",
+    vcsIntegrationId: "vcs-integration-1",
+    issueTrackerIntegrationId: "it-integration-1",
+    ...overrides,
+  };
+}
+
+function makeRegistry(result: Record<string, unknown>): AdapterRegistry {
+  return { execute: vi.fn().mockResolvedValue(result) } as unknown as AdapterRegistry;
+}
+
 describe("executeOnEnter", () => {
   it("skips when all named artifacts already exist on entity", async () => {
     const entity = makeEntity({ artifacts: { worktreePath: "/tmp/wt", branch: "fix-123" } });
     const repo = makeEntityRepo();
+    const registry = makeRegistry({});
     const onEnter: OnEnterConfig = {
-      command: "echo should-not-run",
+      op: "vcs.provision_worktree",
       artifacts: ["worktreePath", "branch"],
     };
 
-    const result = await executeOnEnter(onEnter, entity, repo);
+    const result = await executeOnEnter(onEnter, entity, repo, makeFlow(), registry);
 
     expect(result.skipped).toBe(true);
     expect(result.error).toBeNull();
     expect(repo.updateArtifacts).not.toHaveBeenCalled();
   });
 
-  it("runs command and merges artifacts on success", async () => {
+  it("runs op and merges artifacts on success", async () => {
     const entity = makeEntity();
     const repo = makeEntityRepo();
+    const registry = makeRegistry({ worktreePath: "/tmp/wt", branch: "fix-123" });
     const onEnter: OnEnterConfig = {
-      command: `echo '{"worktreePath":"/tmp/wt","branch":"fix-123"}'`,
+      op: "vcs.provision_worktree",
+      params: { repo: "{{entity.refs.github.repo}}" },
       artifacts: ["worktreePath", "branch"],
     };
 
-    const result = await executeOnEnter(onEnter, entity, repo);
+    const result = await executeOnEnter(onEnter, entity, repo, makeFlow(), registry);
 
     expect(result.skipped).toBe(false);
     expect(result.error).toBeNull();
@@ -92,107 +111,95 @@ describe("executeOnEnter", () => {
       artifacts: { worktreePath: "/tmp/wt", branch: "fix-123", other: "stuff" },
     });
     const repo = makeEntityRepo();
+    const registry = makeRegistry({});
     const onEnter: OnEnterConfig = {
-      command: "echo should-not-run",
+      op: "vcs.provision_worktree",
       artifacts: ["worktreePath", "branch"],
     };
 
-    const result = await executeOnEnter(onEnter, entity, repo);
+    const result = await executeOnEnter(onEnter, entity, repo, makeFlow(), registry);
     expect(result.skipped).toBe(true);
   });
 
-  it("records error when command fails (non-zero exit)", async () => {
+  it("records error when op fails", async () => {
     const entity = makeEntity();
     const repo = makeEntityRepo();
+    const registry = { execute: vi.fn().mockRejectedValue(new Error("op failed")) } as unknown as AdapterRegistry;
     const onEnter: OnEnterConfig = {
-      command: "false",
+      op: "vcs.provision_worktree",
       artifacts: ["worktreePath"],
     };
 
-    const result = await executeOnEnter(onEnter, entity, repo);
+    const result = await executeOnEnter(onEnter, entity, repo, makeFlow(), registry);
 
     expect(result.skipped).toBe(false);
     expect(result.error).toBeTruthy();
     expect(result.artifacts).toBeNull();
     expect(repo.updateArtifacts).toHaveBeenCalledWith("entity-1", {
       onEnter_error: expect.objectContaining({
-        command: "false",
+        op: "vcs.provision_worktree",
         error: expect.any(String),
-        failedAt: expect.any(String),
       }),
     });
   });
 
-  it("preserves actual exit code from failed command (not hardcoded 1)", async () => {
+  it("records error when expected artifact key is missing from op result", async () => {
     const entity = makeEntity();
     const repo = makeEntityRepo();
+    const registry = makeRegistry({ worktreePath: "/tmp/wt" });
     const onEnter: OnEnterConfig = {
-      command: "exit 42",
-      artifacts: ["worktreePath"],
-    };
-
-    const result = await executeOnEnter(onEnter, entity, repo);
-
-    expect(result.skipped).toBe(false);
-    expect(result.error).toMatch(/42/);
-    expect(result.artifacts).toBeNull();
-  });
-
-  it("records error when stdout is not valid JSON", async () => {
-    const entity = makeEntity();
-    const repo = makeEntityRepo();
-    const onEnter: OnEnterConfig = {
-      command: "echo not-json",
-      artifacts: ["worktreePath"],
-    };
-
-    const result = await executeOnEnter(onEnter, entity, repo);
-
-    expect(result.skipped).toBe(false);
-    expect(result.error).toBeTruthy();
-    expect(result.artifacts).toBeNull();
-  });
-
-  it("records error when expected artifact key is missing from stdout", async () => {
-    const entity = makeEntity();
-    const repo = makeEntityRepo();
-    const onEnter: OnEnterConfig = {
-      command: `echo '{"worktreePath":"/tmp/wt"}'`,
+      op: "vcs.provision_worktree",
       artifacts: ["worktreePath", "branch"],
     };
 
-    const result = await executeOnEnter(onEnter, entity, repo);
+    const result = await executeOnEnter(onEnter, entity, repo, makeFlow(), registry);
 
     expect(result.skipped).toBe(false);
     expect(result.error).toContain("branch");
     expect(result.artifacts).toBeNull();
   });
 
-  it("times out when command exceeds timeout_ms", async () => {
+  it("returns error when no adapterRegistry provided", async () => {
     const entity = makeEntity();
     const repo = makeEntityRepo();
     const onEnter: OnEnterConfig = {
-      command: "sleep 10",
+      op: "vcs.provision_worktree",
       artifacts: ["worktreePath"],
-      timeout_ms: 100,
     };
 
-    const result = await executeOnEnter(onEnter, entity, repo);
+    const result = await executeOnEnter(onEnter, entity, repo, makeFlow(), null);
 
     expect(result.skipped).toBe(false);
-    expect(result.timedOut).toBe(true);
-    expect(result.error).toBeTruthy();
+    expect(result.error).toContain("AdapterRegistry");
+    expect(result.artifacts).toBeNull();
+  });
+
+  it("returns error when flow has no vcs integration", async () => {
+    const entity = makeEntity();
+    const repo = makeEntityRepo();
+    const registry = makeRegistry({});
+    const onEnter: OnEnterConfig = {
+      op: "vcs.provision_worktree",
+      artifacts: ["worktreePath"],
+    };
+
+    const result = await executeOnEnter(onEnter, entity, repo, makeFlow({ vcsIntegrationId: undefined }), registry);
+
+    expect(result.skipped).toBe(false);
+    expect(result.error).toContain("vcs");
+    expect(result.artifacts).toBeNull();
   });
 
   it("runs when only some artifacts exist (not all)", async () => {
     const entity = makeEntity({ artifacts: { worktreePath: "/tmp/wt" } });
     const repo = makeEntityRepo();
+    const registry = makeRegistry({ worktreePath: "/tmp/wt2", branch: "fix-456" });
     const onEnter: OnEnterConfig = {
-      command: `echo '{"worktreePath":"/tmp/wt2","branch":"fix-456"}'`,
+      op: "vcs.provision_worktree",
       artifacts: ["worktreePath", "branch"],
     };
 
-    const result = await executeOnEnter(onEnter, entity, repo);
+    const result = await executeOnEnter(onEnter, entity, repo, makeFlow(), registry);
 
     expect(result.skipped).toBe(false);
     expect(result.error).toBeNull();
@@ -207,6 +214,8 @@ describe("Engine onEnter integration", () => {
   let entityRepo: DrizzleEntityRepository;
   let flowRepo: DrizzleFlowRepository;
   let events: Array<{ type: string }>;
+  let mockRegistry: AdapterRegistry;
+  let vcsIntegrationId: string;
 
   beforeEach(async () => {
     const res = await createTestDb();
@@ -215,6 +224,7 @@ describe("Engine onEnter integration", () => {
 
     entityRepo = new DrizzleEntityRepository(db, TEST_TENANT);
     flowRepo = new DrizzleFlowRepository(db, TEST_TENANT);
+    const integrationRepo = new DrizzleIntegrationRepository(db, TEST_TENANT);
     const invocationRepo = new DrizzleInvocationRepository(db, TEST_TENANT);
     const gateRepo = new DrizzleGateRepository(db, TEST_TENANT);
     const transitionRepo: ITransitionLogRepository = {
@@ -228,6 +238,18 @@ describe("Engine onEnter integration", () => {
       },
     };
 
+    const vcsInt = await integrationRepo.create({
+      name: "test-vcs",
+      category: "vcs",
+      provider: "github",
+      credentials: { provider: "github", accessToken: "test-token" },
+    });
+    vcsIntegrationId = vcsInt.id;
+
+    mockRegistry = {
+      execute: vi.fn().mockResolvedValue({ worktreePath: "/tmp/wt", branch: "fix-1" }),
+    } as unknown as AdapterRegistry;
+
     engine = new Engine({
       entityRepo,
       flowRepo,
@@ -236,6 +258,7 @@ describe("Engine onEnter integration", () => {
       transitionLogRepo: transitionRepo,
       adapters: new Map(),
       eventEmitter,
+      adapterRegistry: mockRegistry,
     });
   });
 
@@ -244,14 +267,14 @@ describe("Engine onEnter integration", () => {
   });
 
   it("onEnter runs and artifacts are merged before invocation creation", async () => {
-    const flow = await flowRepo.create({ name: "test-flow", initialState: "triage" });
+    const flow = await flowRepo.create({ name: "test-flow", initialState: "triage", vcsIntegrationId });
     await flowRepo.addState(flow.id, { name: "triage", agentRole: "triager", promptTemplate: "triage this" });
     await flowRepo.addState(flow.id, {
       name: "coding",
       agentRole: "coder",
       promptTemplate: "code at {{entity.artifacts.worktreePath}}",
       onEnter: {
-        command: `echo '{"worktreePath":"/tmp/wt","branch":"fix-1"}'`,
+        op: "vcs.provision_worktree",
         artifacts: ["worktreePath", "branch"],
       },
     });
@@ -275,14 +298,14 @@ describe("Engine onEnter integration", () => {
   });
 
   it("onEnter re-runs on re-entry (stale artifacts are cleared)", async () => {
-    const flow = await flowRepo.create({ name: "test-flow2", initialState: "triage" });
+    const flow = await flowRepo.create({ name: "test-flow2", initialState: "triage", vcsIntegrationId });
     await flowRepo.addState(flow.id, { name: "triage", agentRole: "triager", promptTemplate: "triage" });
     await flowRepo.addState(flow.id, {
       name: "coding",
       agentRole: "coder",
       promptTemplate: "code",
       onEnter: {
-        command: `echo '{"worktreePath":"/tmp/wt","branch":"fix-1"}'`,
+        op: "vcs.provision_worktree",
         artifacts: ["worktreePath", "branch"],
       },
     });
@@ -297,20 +320,21 @@ describe("Engine onEnter integration", () => {
     events.length = 0;
     await engine.processSignal(entity.id, "fix");
 
-    // On re-entry, stale keys are cleared so the hook re-runs (onEnter.completed, not onEnter.skipped)
     expect(events).toContainEqual(expect.objectContaining({ type: "onEnter.completed" }));
     expect(events.some((e) => e.type === "onEnter.skipped")).toBe(false);
   });
 
   it("onEnter failure gates the entity", async () => {
-    const flow = await flowRepo.create({ name: "test-flow3", initialState: "triage" });
+    (mockRegistry.execute as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("op failed"));
+
+    const flow = await flowRepo.create({ name: "test-flow3", initialState: "triage", vcsIntegrationId });
     await flowRepo.addState(flow.id, { name: "triage", agentRole: "triager", promptTemplate: "triage" });
     await flowRepo.addState(flow.id, {
       name: "coding",
       agentRole: "coder",
       promptTemplate: "code",
       onEnter: {
-        command: "false",
+        op: "vcs.provision_worktree",
         artifacts: ["worktreePath"],
       },
     });
@@ -341,8 +365,20 @@ describe("Engine onEnter integration", () => {
 
     const entityRepo2 = new DrizzleEntityRepository(db2, TEST_TENANT);
     const flowRepo2 = new DrizzleFlowRepository(db2, TEST_TENANT);
+    const integrationRepo2 = new DrizzleIntegrationRepository(db2, TEST_TENANT);
     const invocationRepo2 = new DrizzleInvocationRepository(db2, TEST_TENANT);
     const gateRepo2 = new DrizzleGateRepository(db2, TEST_TENANT);
+
+    const vcsInt2 = await integrationRepo2.create({
+      name: "test-vcs",
+      category: "vcs",
+      provider: "github",
+      credentials: { provider: "github", accessToken: "test-token" },
+    });
+
+    const failRegistry = {
+      execute: vi.fn().mockRejectedValue(new Error("op failed")),
+    } as unknown as AdapterRegistry;
 
     const engine2 = new Engine({
       entityRepo: entityRepo2,
@@ -352,15 +388,16 @@ describe("Engine onEnter integration", () => {
       transitionLogRepo: spyTransitionRepo,
       adapters: new Map(),
       eventEmitter: { emit: async () => {} },
+      adapterRegistry: failRegistry,
     });
 
-    const flow2 = await flowRepo2.create({ name: "test-flow4b", initialState: "triage" });
+    const flow2 = await flowRepo2.create({ name: "test-flow4b", initialState: "triage", vcsIntegrationId: vcsInt2.id });
     await flowRepo2.addState(flow2.id, { name: "triage", agentRole: "triager", promptTemplate: "triage" });
     await flowRepo2.addState(flow2.id, {
       name: "coding",
       agentRole: "coder",
       promptTemplate: "code",
-      onEnter: { command: "false", artifacts: ["worktreePath"] },
+      onEnter: { op: "vcs.provision_worktree", artifacts: ["worktreePath"] },
     });
     await flowRepo2.addTransition(flow2.id, { fromState: "triage", toState: "coding", trigger: "approved" });
 
@@ -379,12 +416,14 @@ describe("Engine onEnter integration", () => {
   });
 
   it("createEntity throws when onEnter fails on initial state", async () => {
-    const flow = await flowRepo.create({ name: "test-flow5", initialState: "setup" });
+    (mockRegistry.execute as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("op failed"));
+
+    const flow = await flowRepo.create({ name: "test-flow5", initialState: "setup", vcsIntegrationId });
     await flowRepo.addState(flow.id, {
       name: "setup",
       agentRole: "setupper",
       promptTemplate: "setup",
-      onEnter: { command: "false", artifacts: ["worktreePath"] },
+      onEnter: { op: "vcs.provision_worktree", artifacts: ["worktreePath"] },
     });
 
     await expect(engine.createEntity("test-flow5")).rejects.toThrow("onEnter failed");
@@ -416,7 +455,6 @@ describe("Engine onEnter integration", () => {
     await flowRepo.addState(flow.id, { name: "init", agentRole: "worker", promptTemplate: "go" });
     const entity = await engine.createEntity("test-rmkeys-null");
 
-    // Should not throw
     await entityRepo.removeArtifactKeys(entity.id, ["nonexistent"]);
 
     const updated = await entityRepo.get(entity.id);
@@ -424,14 +462,16 @@ describe("Engine onEnter integration", () => {
   });
 
   it("onEnter re-runs on re-entry after artifact keys are cleared", async () => {
-    const flow = await flowRepo.create({ name: "test-reentry", initialState: "triage" });
+    (mockRegistry.execute as ReturnType<typeof vi.fn>).mockResolvedValue({ prDiff: "the-diff", prComments: "the-comments" });
+
+    const flow = await flowRepo.create({ name: "test-reentry", initialState: "triage", vcsIntegrationId });
     await flowRepo.addState(flow.id, { name: "triage", agentRole: "triager", promptTemplate: "triage" });
     await flowRepo.addState(flow.id, {
       name: "reviewing",
       agentRole: "reviewer",
       promptTemplate: "review {{entity.artifacts.prDiff}}",
       onEnter: {
-        command: `echo '{"prDiff":"the-diff","prComments":"the-comments"}'`,
+        op: "vcs.fetch_pr_diff",
         artifacts: ["prDiff", "prComments"],
       },
     });
@@ -442,24 +482,20 @@ describe("Engine onEnter integration", () => {
 
     const entity = await engine.createEntity("test-reentry");
 
-    // First entry into reviewing — onEnter runs
     const r1 = await engine.processSignal(entity.id, "ready");
     expect(r1.newState).toBe("reviewing");
     const e1 = await entityRepo.get(entity.id);
     expect(e1?.artifacts).toHaveProperty("prDiff");
     expect(e1?.artifacts).toHaveProperty("prComments");
 
-    // Transition to fixing, then back to reviewing
     await engine.processSignal(entity.id, "needs_fix");
     const r2 = await engine.processSignal(entity.id, "fixed");
     expect(r2.newState).toBe("reviewing");
 
-    // onEnter must have re-run (not skipped)
     const e2 = await entityRepo.get(entity.id);
     expect(e2?.artifacts).toHaveProperty("prDiff");
     expect(e2?.artifacts).toHaveProperty("prComments");
 
-    // Verify onEnter.completed fired (not onEnter.skipped)
     const completedEvents = events.filter(
       (e) => e.type === "onEnter.completed" && (e as Record<string, unknown>)["state"] === "reviewing",
     );
@@ -467,13 +503,17 @@ describe("Engine onEnter integration", () => {
   });
 
   it("artifacts from other states are NOT cleared on re-entry", async () => {
-    const flow = await flowRepo.create({ name: "test-reentry-preserve", initialState: "provisioning" });
+    (mockRegistry.execute as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ worktreePath: "/tmp/wt", branch: "fix-1" })
+      .mockResolvedValue({ prDiff: "the-diff", prComments: "the-comments" });
+
+    const flow = await flowRepo.create({ name: "test-reentry-preserve", initialState: "provisioning", vcsIntegrationId });
     await flowRepo.addState(flow.id, {
       name: "provisioning",
       agentRole: "provisioner",
       promptTemplate: "provision",
       onEnter: {
-        command: `echo '{"worktreePath":"/tmp/wt","branch":"fix-1"}'`,
+        op: "vcs.provision_worktree",
         artifacts: ["worktreePath", "branch"],
       },
     });
@@ -482,7 +522,7 @@ describe("Engine onEnter integration", () => {
       agentRole: "reviewer",
       promptTemplate: "review",
       onEnter: {
-        command: `echo '{"prDiff":"the-diff","prComments":"the-comments"}'`,
+        op: "vcs.fetch_pr_diff",
         artifacts: ["prDiff", "prComments"],
       },
     });
@@ -493,16 +533,13 @@ describe("Engine onEnter integration", () => {
 
     const entity = await engine.createEntity("test-reentry-preserve");
 
-    // provisioning → reviewing → fixing → reviewing
     await engine.processSignal(entity.id, "ready");
     await engine.processSignal(entity.id, "needs_fix");
     await engine.processSignal(entity.id, "fixed");
 
     const final = await entityRepo.get(entity.id);
-    // Provisioning artifacts must survive
     expect(final?.artifacts).toHaveProperty("worktreePath", "/tmp/wt");
     expect(final?.artifacts).toHaveProperty("branch", "fix-1");
-    // Reviewing artifacts must be fresh (re-run)
     expect(final?.artifacts).toHaveProperty("prDiff", "the-diff");
     expect(final?.artifacts).toHaveProperty("prComments", "the-comments");
   });

--- a/tests/on-exit.test.ts
+++ b/tests/on-exit.test.ts
@@ -6,6 +6,8 @@ import { DrizzleEntityRepository } from "../src/repositories/drizzle/entity.repo
 import { DrizzleFlowRepository } from "../src/repositories/drizzle/flow.repo.js";
 import { DrizzleGateRepository } from "../src/repositories/drizzle/gate.repo.js";
 import { DrizzleInvocationRepository } from "../src/repositories/drizzle/invocation.repo.js";
+import { DrizzleIntegrationRepository } from "../src/integrations/repo.js";
+import type { AdapterRegistry } from "../src/integrations/registry.js";
 import type {
   Entity,
   IEventBusAdapter,
@@ -35,38 +37,78 @@ function makeEntity(overrides?: Partial<Entity>): Entity {
   };
 }
 
+function makeFlow(overrides?: object) {
+  return {
+    id: "flow-1",
+    name: "test-flow",
+    vcsIntegrationId: "vcs-integration-1",
+    issueTrackerIntegrationId: "it-integration-1",
+    ...overrides,
+  };
+}
+
+function makeRegistry(): AdapterRegistry {
+  return { execute: vi.fn().mockResolvedValue({}) } as unknown as AdapterRegistry;
+}
+
 describe("executeOnExit", () => {
-  it("runs a command and returns success", async () => {
-    const config: OnExitConfig = { command: "echo hello", timeout_ms: 5000 };
-    const result = await executeOnExit(config, makeEntity());
+  it("executes a primitive op and returns success", async () => {
+    const registry = makeRegistry();
+    const config: OnExitConfig = { op: "vcs.cleanup_worktree" };
+    const result = await executeOnExit(config, makeEntity(), makeFlow(), registry);
     expect(result.error).toBeNull();
+    expect(result.timedOut).toBe(false);
+    expect(registry.execute).toHaveBeenCalledOnce();
+  });
+
+  it("renders Handlebars template params from entity", async () => {
+    const registry = makeRegistry();
+    const config: OnExitConfig = {
+      op: "vcs.cleanup_worktree",
+      params: { path: "{{entity.artifacts.worktreePath}}" },
+    };
+    const result = await executeOnExit(config, makeEntity(), makeFlow(), registry);
+    expect(result.error).toBeNull();
+    expect(registry.execute).toHaveBeenCalledWith(
+      "vcs-integration-1",
+      "vcs.cleanup_worktree",
+      { path: "/tmp/wt-123" },
+    );
+  });
+
+  it("returns error when op throws", async () => {
+    const registry = {
+      execute: vi.fn().mockRejectedValue(new Error("op failed")),
+    } as unknown as AdapterRegistry;
+    const config: OnExitConfig = { op: "vcs.cleanup_worktree" };
+    const result = await executeOnExit(config, makeEntity(), makeFlow(), registry);
+    expect(result.error).toContain("op failed");
     expect(result.timedOut).toBe(false);
   });
 
-  it("renders Handlebars template vars from entity", async () => {
-    const config: OnExitConfig = { command: "echo {{entity.artifacts.worktreePath}}" };
-    const result = await executeOnExit(config, makeEntity());
-    expect(result.error).toBeNull();
-  });
-
-  it("returns error on non-zero exit code without throwing", async () => {
-    const config: OnExitConfig = { command: "exit 1" };
-    const result = await executeOnExit(config, makeEntity());
-    expect(result.error).toContain("exited with code");
-    expect(result.timedOut).toBe(false);
-  });
-
-  it("returns timedOut on timeout without throwing", async () => {
-    const config: OnExitConfig = { command: "sleep 10", timeout_ms: 50 };
-    const result = await executeOnExit(config, makeEntity());
-    expect(result.error).toContain("timed out");
-    expect(result.timedOut).toBe(true);
-  });
-
-  it("returns error on template rendering failure without throwing", async () => {
-    const config: OnExitConfig = { command: "echo {{#each broken" };
-    const result = await executeOnExit(config, makeEntity());
+  it("returns error on template rendering failure", async () => {
+    const registry = makeRegistry();
+    const config: OnExitConfig = {
+      op: "vcs.cleanup_worktree",
+      params: { path: "{{#each broken" },
+    };
+    const result = await executeOnExit(config, makeEntity(), makeFlow(), registry);
     expect(result.error).toContain("onExit template error");
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("returns error when no adapterRegistry provided", async () => {
+    const config: OnExitConfig = { op: "vcs.cleanup_worktree" };
+    const result = await executeOnExit(config, makeEntity(), makeFlow(), null);
+    expect(result.error).toContain("AdapterRegistry");
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("returns error when flow has no vcs integration", async () => {
+    const registry = makeRegistry();
+    const config: OnExitConfig = { op: "vcs.cleanup_worktree" };
+    const result = await executeOnExit(config, makeEntity(), makeFlow({ vcsIntegrationId: undefined }), registry);
+    expect(result.error).toContain("vcs");
     expect(result.timedOut).toBe(false);
   });
 });
@@ -78,6 +120,8 @@ describe("Engine.processSignal onExit integration", () => {
   let flowRepo: DrizzleFlowRepository;
   let entityRepo: DrizzleEntityRepository;
   let emittedEvents: Array<{ type: string; [key: string]: unknown }>;
+  let mockRegistry: AdapterRegistry;
+  let vcsIntegrationId: string;
 
   beforeEach(async () => {
     const res = await createTestDb();
@@ -86,8 +130,18 @@ describe("Engine.processSignal onExit integration", () => {
 
     flowRepo = new DrizzleFlowRepository(db, TEST_TENANT);
     entityRepo = new DrizzleEntityRepository(db, TEST_TENANT);
+    const integrationRepo = new DrizzleIntegrationRepository(db, TEST_TENANT);
     const invocationRepo = new DrizzleInvocationRepository(db, TEST_TENANT);
     const gateRepo = new DrizzleGateRepository(db, TEST_TENANT);
+
+    const vcsInt = await integrationRepo.create({
+      name: "test-vcs",
+      category: "vcs",
+      provider: "github",
+      credentials: { provider: "github", accessToken: "test-token" },
+    });
+    vcsIntegrationId = vcsInt.id;
+
     emittedEvents = [];
     const eventEmitter: IEventBusAdapter = {
       emit: async (event) => {
@@ -107,6 +161,10 @@ describe("Engine.processSignal onExit integration", () => {
       historyFor: vi.fn(async () => []),
     };
 
+    mockRegistry = {
+      execute: vi.fn().mockResolvedValue({}),
+    } as unknown as AdapterRegistry;
+
     engine = new Engine({
       entityRepo,
       flowRepo,
@@ -115,6 +173,7 @@ describe("Engine.processSignal onExit integration", () => {
       transitionLogRepo,
       adapters: new Map(),
       eventEmitter,
+      adapterRegistry: mockRegistry,
     });
   });
 
@@ -122,17 +181,18 @@ describe("Engine.processSignal onExit integration", () => {
     await close();
   });
 
-  it("runs onExit on the departing state when gate passes", async () => {
+  it("runs onExit on the departing state when transitioning", async () => {
     const flow = await flowRepo.create({
       name: "test-flow",
       initialState: "coding",
       discipline: "engineering",
+      vcsIntegrationId,
     });
     await flowRepo.addState(flow.id, {
       name: "coding",
       mode: "active",
       promptTemplate: "do coding",
-      onExit: { command: "echo exiting", timeout_ms: 5000 },
+      onExit: { op: "vcs.cleanup_worktree" },
     });
     await flowRepo.addState(flow.id, { name: "review", mode: "passive" });
     await flowRepo.addTransition(flow.id, {
@@ -147,19 +207,23 @@ describe("Engine.processSignal onExit integration", () => {
     const exitEvents = emittedEvents.filter((e) => e.type === "onExit.completed");
     expect(exitEvents).toHaveLength(1);
     expect(exitEvents[0].state).toBe("coding");
+    expect(mockRegistry.execute).toHaveBeenCalledOnce();
   });
 
   it("does not block transition when onExit fails", async () => {
+    (mockRegistry.execute as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("op failed"));
+
     const flow = await flowRepo.create({
       name: "test-flow-2",
       initialState: "coding",
       discipline: "engineering",
+      vcsIntegrationId,
     });
     await flowRepo.addState(flow.id, {
       name: "coding",
       mode: "active",
       promptTemplate: "do coding",
-      onExit: { command: "exit 1", timeout_ms: 5000 },
+      onExit: { op: "vcs.cleanup_worktree" },
     });
     await flowRepo.addState(flow.id, { name: "review", mode: "passive" });
     await flowRepo.addTransition(flow.id, {
@@ -197,5 +261,38 @@ describe("Engine.processSignal onExit integration", () => {
     expect(result.newState).toBe("review");
     const exitEvents = emittedEvents.filter((e) => e.type.startsWith("onExit."));
     expect(exitEvents).toHaveLength(0);
+  });
+
+  it("passes rendered params to the adapter", async () => {
+    const flow = await flowRepo.create({
+      name: "test-flow-params",
+      initialState: "coding",
+      discipline: "engineering",
+      vcsIntegrationId,
+    });
+    await flowRepo.addState(flow.id, {
+      name: "coding",
+      mode: "active",
+      promptTemplate: "do coding",
+      onExit: {
+        op: "vcs.cleanup_worktree",
+        params: { entityId: "{{entity.id}}" },
+      },
+    });
+    await flowRepo.addState(flow.id, { name: "review", mode: "passive" });
+    await flowRepo.addTransition(flow.id, {
+      fromState: "coding",
+      toState: "review",
+      trigger: "spec_ready",
+    });
+
+    const entity = await entityRepo.create(flow.id, "coding");
+    await engine.processSignal(entity.id, "spec_ready");
+
+    expect(mockRegistry.execute).toHaveBeenCalledWith(
+      vcsIntegrationId,
+      "vcs.cleanup_worktree",
+      { entityId: entity.id },
+    );
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    env: {
+      // 64-char hex key (32 bytes) for integration tests that use DrizzleIntegrationRepository
+      SILO_ENCRYPTION_KEY: "0".repeat(64),
+    },
     testTimeout: 30000,
     exclude: ["dist/**", "node_modules/**"],
     coverage: {


### PR DESCRIPTION
## Summary

- Removes `execFile`/`child_process` shell execution from `onEnter` and `onExit`
- `OnEnterConfig` and `OnExitConfig` now use `op: string` (a named primitive op like `vcs.provision_worktree`) + optional `params`
- Shell `command` field is gone entirely — the engine only dispatches through `AdapterRegistry`
- Zod schemas updated: `OnEnterSchema` and `OnExitSchema` now validate `op` against the `PRIMITIVE_OPS` enum
- Engine constructor accepts optional `adapterRegistry` directly (for testing)
- `vitest.config.ts` sets `SILO_ENCRYPTION_KEY` env var so integration tests using `DrizzleIntegrationRepository` pass without extra setup
- All 994 tests pass, `pnpm run check` clean

## Motivation

`onEnter`/`onExit` shell execution is an RCE surface in a multi-tenant SaaS context. Any flow config stored in the DB could inject arbitrary shell commands. Primitive adapter ops dispatch through the typed `AdapterRegistry` with no shell involvement.

## Linear

Closes WOP-2160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace onEnter/onExit shell commands with primitive adapter operations wired through AdapterRegistry and update engine wiring, validation, and tests accordingly.

New Features:
- Support passing a pre-built AdapterRegistry into the Engine constructor for use by hooks and tests.

Enhancements:
- Refine onEnter/onExit configuration to require named primitive ops with optional template-rendered params instead of arbitrary shell commands.
- Route onEnter/onExit execution through integration-backed AdapterRegistry using flow integration IDs, removing child_process usage and command timeouts.
- Update Zod schemas for onEnter/onExit to validate primitive ops against the PRIMITIVE_OPS enum and accept optional params.

Tests:
- Adapt unit and integration tests for onEnter/onExit to exercise primitive op execution via AdapterRegistry, including error paths and parameter rendering.
- Extend integration tests to create test VCS integrations for flows and to verify adapter invocation semantics.
- Configure Vitest to set SILO_ENCRYPTION_KEY in the test environment for integration tests using DrizzleIntegrationRepository.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove shell execution from `onEnter`/`onExit` hooks in favor of primitive adapter ops
> - Replaces shell command execution (with timeout and stdout parsing) in [`on-enter.ts`](https://github.com/wopr-network/silo/pull/159/files#diff-ff683376c5ea6b2593de06a7afec61f7d035e959ff1e5e50ed3821acc227f0f1) and [`on-exit.ts`](https://github.com/wopr-network/silo/pull/159/files#diff-e7c8c6f9cdb614710ddd152c6083244898d8a1359019f3f9bce2c73094e62151) with primitive adapter op execution via `AdapterRegistry`.
> - `OnEnterConfig` and `OnExitConfig` types and Zod schemas now require `op` and optional `params` instead of `command` and `timeout_ms`.
> - The engine now accepts an optional `adapterRegistry` in `EngineDeps` and passes flow context and the registry to `executeOnExit` during state transitions.
> - `onExit` supports Handlebars-rendered params using entity context; `onEnter` merges op result artifacts onto the entity.
> - Risk: Breaking change — any existing `onEnter`/`onExit` configurations using `command` or `timeout_ms` fields are no longer valid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7aee51b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->