### PR TITLE
security: add auth to all unprotected HTTP endpoints (WOP-2182/2183/2184/2185)

### DIFF
--- a/src/api/hono-server.ts
+++ b/src/api/hono-server.ts
@@ -319,6 +319,22 @@ export function createHonoApp(deps: HonoServerDeps): Hono {
     };
   }
 
+  // biome-ignore lint/suspicious/noConfusingVoidType: Hono middleware next() returns void
+  function requireAuth(): (c: import("hono").Context, next: () => Promise<void>) => Promise<Response | void> {
+    return async (c, next) => {
+      const callerToken = extractBearerToken(c.req.header("authorization"));
+      if (!callerToken) {
+        return c.json({ error: "Unauthorized: this endpoint requires authentication." }, 401);
+      }
+      const workerOk = deps.workerToken?.trim() && tokensMatch(deps.workerToken.trim(), callerToken);
+      const adminOk = deps.adminToken?.trim() && tokensMatch(deps.adminToken.trim(), callerToken);
+      if (!workerOk && !adminOk) {
+        return c.json({ error: "Unauthorized: this endpoint requires authentication." }, 401);
+      }
+      return next();
+    };
+  }
+
   // ─── JSON body parser with explicit error ───
   async function parseJsonBody(c: import("hono").Context): Promise<Record<string, unknown> | null> {
     try {
@@ -329,7 +345,7 @@ export function createHonoApp(deps: HonoServerDeps): Hono {
   }
 
   // ─── Status ───
-  app.get("/api/status", async (c) => {
+  app.get("/api/status", requireAuth(), async (c) => {
     const status = await (await getEngine(c)).getStatus();
     return c.json(status);
   });
@@ -380,7 +396,7 @@ export function createHonoApp(deps: HonoServerDeps): Hono {
   });
 
   // ─── Entity CRUD ───
-  app.post("/api/entities", async (c) => {
+  app.post("/api/entities", requireWorkerAuth(), async (c) => {
     const body = await parseJsonBody(c);
     if (!body) return c.json({ error: "Invalid JSON" }, 400);
     const flowName = body.flow as string;
@@ -397,13 +413,13 @@ export function createHonoApp(deps: HonoServerDeps): Hono {
     }
   });
 
-  app.get("/api/entities/:id", async (c) => {
+  app.get("/api/entities/:id", requireAuth(), async (c) => {
     const result = await callToolHandler(await getMcpDeps(c), "query.entity", { id: c.req.param("id") });
     const { status, body: resBody } = mcpResultToResponse(result);
     return c.json(resBody as Record<string, unknown>, status as 200);
   });
 
-  app.get("/api/entities", async (c) => {
+  app.get("/api/entities", requireAuth(), async (c) => {
     const flow = c.req.query("flow");
     const state = c.req.query("state");
     if (!flow || !state) return c.json({ error: "Required query params: flow, state" }, 400);
@@ -468,25 +484,25 @@ export function createHonoApp(deps: HonoServerDeps): Hono {
   });
 
   // ─── Flow definitions ───
-  app.get("/api/flows", async (c) => {
+  app.get("/api/flows", requireAuth(), async (c) => {
     const flows = await (await getMcpDeps(c)).flows.listAll();
     return c.json(flows as unknown as Record<string, unknown>[]);
   });
 
-  app.get("/api/flows/:id", async (c) => {
+  app.get("/api/flows/:id", requireAuth(), async (c) => {
     const result = await callToolHandler(await getMcpDeps(c), "query.flow", { name: c.req.param("id") });
     const { status, body: resBody } = mcpResultToResponse(result);
     return c.json(resBody as Record<string, unknown>, status as 200);
   });
 
-  app.put("/api/flows/:id", async (c) => {
+  app.put("/api/flows/:id", requireAdminAuth(), async (c) => {
     let body: Record<string, unknown>;
     try {
       body = (await c.req.json()) as Record<string, unknown>;
     } catch {
       return c.json({ error: "Invalid JSON body" }, 400);
     }
-    const flowName = c.req.param("id");
+    const flowName = c.req.param("id") ?? "";
     const existing = await (await getMcpDeps(c)).flows.getByName(flowName);
     const callerToken = extractBearerToken(c.req.header("authorization"));
     const toolName = existing ? "admin.flow.update" : "admin.flow.create";
@@ -501,7 +517,7 @@ export function createHonoApp(deps: HonoServerDeps): Hono {
     return c.json(resBody as Record<string, unknown>, status as 200);
   });
 
-  app.delete("/api/flows/:id", async (c) => {
+  app.delete("/api/flows/:id", requireAdminAuth(), async (c) => {
     return c.json({ error: "Flow deletion not implemented" }, 501);
   });
 

--- a/tests/api/server.test.ts
+++ b/tests/api/server.test.ts
@@ -34,7 +34,7 @@ async function makeTestDeps(): Promise<HonoServerDeps & { stopReaper: () => Prom
     engine,
   };
 
-  return { engine, mcpDeps, db, defaultTenantId: "test-tenant", eventEmitter, adminToken: undefined, workerToken: "test-worker-token", stopReaper, closeDb: close };
+  return { engine, mcpDeps, db, defaultTenantId: "test-tenant", eventEmitter, adminToken: "test-admin-token", workerToken: "test-worker-token", stopReaper, closeDb: close };
 }
 
 async function startTestServer(deps: HonoServerDeps): Promise<{ server: http.Server; port: number }> {
@@ -47,6 +47,9 @@ async function startTestServer(deps: HonoServerDeps): Promise<{ server: http.Ser
   const port = (server.address() as { port: number }).port;
   return { server, port };
 }
+
+const workerHeaders = { Authorization: "Bearer test-worker-token" };
+const adminHeaders = { Authorization: "Bearer test-admin-token" };
 
 // ─── HTTP server integration tests ───────────────────────────────────────────
 
@@ -69,7 +72,7 @@ describe("HTTP Server - basic", () => {
   });
 
   it("GET /api/status returns engine status", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/status`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/status`, { headers: workerHeaders });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveProperty("flows");
@@ -83,21 +86,21 @@ describe("HTTP Server - basic", () => {
   });
 
   it("GET /api/flows returns empty array initially", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/flows`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/flows`, { headers: workerHeaders });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual([]);
   });
 
   it("GET /api/entities without query params returns 400", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/entities`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/entities`, { headers: workerHeaders });
     expect(res.status).toBe(400);
   });
 
   it("POST /api/entities with missing flow returns 400", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/entities`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...workerHeaders },
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(400);
@@ -106,14 +109,14 @@ describe("HTTP Server - basic", () => {
   it("POST /api/entities with unknown flow returns 4xx", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/entities`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...workerHeaders },
       body: JSON.stringify({ flow: "nonexistent-flow" }),
     });
     expect(res.status).toBeGreaterThanOrEqual(400);
   });
 
   it("GET /api/entities/:id for missing entity returns 404", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/entities/does-not-exist`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/entities/does-not-exist`, { headers: workerHeaders });
     expect(res.status).toBe(404);
   });
 
@@ -128,6 +131,7 @@ describe("HTTP Server - basic", () => {
   it("DELETE /api/flows/:id returns 501", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/flows/some-flow`, {
       method: "DELETE",
+      headers: adminHeaders,
     });
     expect(res.status).toBe(501);
   });
@@ -145,7 +149,7 @@ describe("HTTP Server - basic", () => {
   it("POST with invalid JSON returns 400", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/entities`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...workerHeaders },
       body: "not valid json{{{",
     });
     expect(res.status).toBe(400);
@@ -155,7 +159,7 @@ describe("HTTP Server - basic", () => {
 
   it("CORS header not set for non-loopback origin", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/status`, {
-      headers: { Origin: "https://evil.com" },
+      headers: { Origin: "https://evil.com", ...workerHeaders },
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
@@ -163,7 +167,7 @@ describe("HTTP Server - basic", () => {
 
   it("CORS header set for loopback origin", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/status`, {
-      headers: { Origin: "http://127.0.0.1:3000" },
+      headers: { Origin: "http://127.0.0.1:3000", ...workerHeaders },
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://127.0.0.1:3000");
@@ -178,36 +182,36 @@ describe("HTTP Server - basic", () => {
   });
 
   it("GET /api/entities with only flow param returns 400", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/entities?flow=test`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/entities?flow=test`, { headers: workerHeaders });
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toBe("Required query params: flow, state");
   });
 
   it("GET /api/entities with only state param returns 400", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/entities?state=init`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/entities?state=init`, { headers: workerHeaders });
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toBe("Required query params: flow, state");
   });
 
   it("GET /api/entities with valid flow+state returns non-400", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/entities?flow=test&state=init`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/entities?flow=test&state=init`, { headers: workerHeaders });
     expect(res.status).not.toBe(400);
   });
 
   it("GET /api/entities with limit param returns non-400", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/entities?flow=test&state=init&limit=5`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/entities?flow=test&state=init&limit=5`, { headers: workerHeaders });
     expect(res.status).not.toBe(400);
   });
 
   it("GET /api/entities with invalid limit param ignored", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/entities?flow=test&state=init&limit=abc`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/entities?flow=test&state=init&limit=abc`, { headers: workerHeaders });
     expect(res.status).not.toBe(400);
   });
 
   it("GET /api/flows/:id for unknown flow returns 404", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/flows/nonexistent-flow-xyz`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/flows/nonexistent-flow-xyz`, { headers: workerHeaders });
     expect(res.status).toBe(404);
   });
 
@@ -271,21 +275,21 @@ describe("HTTP Server - explicit CORS origin", () => {
 
   it("reflects matching explicit CORS origin", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/status`, {
-      headers: { Origin: "https://app.example.com" },
+      headers: { Origin: "https://app.example.com", ...workerHeaders },
     });
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://app.example.com");
   });
 
   it("does not reflect non-matching origin", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/status`, {
-      headers: { Origin: "https://other.com" },
+      headers: { Origin: "https://other.com", ...workerHeaders },
     });
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
   it("does not reflect loopback when explicit origin is set", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/status`, {
-      headers: { Origin: "http://localhost:4000" },
+      headers: { Origin: "http://localhost:4000", ...workerHeaders },
     });
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
@@ -316,7 +320,7 @@ describe("HTTP Server - handler error", () => {
   });
 
   it("returns 500 when handler throws", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/status`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/status`, { headers: workerHeaders });
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe("Internal server error");
@@ -344,7 +348,7 @@ describe("HTTP Server - tenant isolation via x-tenant-id", () => {
   });
 
   it("uses default tenant when x-tenant-id header is absent", async () => {
-    const res = await fetch(`http://127.0.0.1:${port}/api/flows`);
+    const res = await fetch(`http://127.0.0.1:${port}/api/flows`, { headers: workerHeaders });
     expect(res.status).toBe(200);
     const flows = await res.json();
     expect(Array.isArray(flows)).toBe(true);
@@ -352,7 +356,7 @@ describe("HTTP Server - tenant isolation via x-tenant-id", () => {
 
   it("returns empty flows for a different tenant", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/flows`, {
-      headers: { "x-tenant-id": "other-tenant" },
+      headers: { "x-tenant-id": "other-tenant", ...workerHeaders },
     });
     expect(res.status).toBe(200);
     const flows = await res.json();
@@ -361,7 +365,7 @@ describe("HTTP Server - tenant isolation via x-tenant-id", () => {
 
   it("status works for a different tenant", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/status`, {
-      headers: { "x-tenant-id": "other-tenant" },
+      headers: { "x-tenant-id": "other-tenant", ...workerHeaders },
     });
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/tests/api/worker-auth-rest.test.ts
+++ b/tests/api/worker-auth-rest.test.ts
@@ -113,18 +113,18 @@ describe("REST worker auth", () => {
     expect(res.status).toBe(401);
   });
 
-  it("GET /api/entities remains open (no auth required)", async () => {
+  it("GET /api/entities returns 401 without token", async () => {
     const res = await request(port, "GET", "/api/entities?flow=test&state=open");
-    expect(res.status).not.toBe(401);
+    expect(res.status).toBe(401);
   });
 
-  it("GET /api/flows remains open (no auth required)", async () => {
+  it("GET /api/flows returns 401 without token", async () => {
     const res = await request(port, "GET", "/api/flows");
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
   });
 
-  it("GET /api/status remains open (no auth required)", async () => {
+  it("GET /api/status returns 401 without token", async () => {
     const res = await request(port, "GET", "/api/status");
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
   });
 });

--- a/tests/e2e/silo.e2e.test.ts
+++ b/tests/e2e/silo.e2e.test.ts
@@ -210,7 +210,7 @@ describe("E2E: full-stack silo flow", { timeout: 15000 }, () => {
 			expect(approveResult.terminal).toBe(true);
 
 			// 6. Verify entity is in done state via GET
-			const getRes = await fetch(`http://127.0.0.1:${ctx.port}/api/entities/${entity.id}`);
+			const getRes = await fetch(`http://127.0.0.1:${ctx.port}/api/entities/${entity.id}`, { headers: workerHeaders() });
 			expect(getRes.status).toBe(200);
 			const finalEntity = (await getRes.json()) as { state: string };
 			expect(finalEntity.state).toBe("done");
@@ -370,7 +370,7 @@ describe("E2E: full-stack silo flow", { timeout: 15000 }, () => {
 			expect(cancelRes.status).toBe(200);
 
 			// Verify entity is now in cancelled state
-			const getRes = await fetch(`http://127.0.0.1:${ctx.port}/api/entities/${entity.id}`);
+			const getRes = await fetch(`http://127.0.0.1:${ctx.port}/api/entities/${entity.id}`, { headers: workerHeaders() });
 			const cancelled = (await getRes.json()) as { state: string };
 			expect(cancelled.state).toBe("cancelled");
 		});
@@ -402,7 +402,7 @@ describe("E2E: full-stack silo flow", { timeout: 15000 }, () => {
 			expect(resetRes.status).toBe(200);
 
 			// Verify via GET
-			const getRes = await fetch(`http://127.0.0.1:${ctx.port}/api/entities/${entity.id}`);
+			const getRes = await fetch(`http://127.0.0.1:${ctx.port}/api/entities/${entity.id}`, { headers: workerHeaders() });
 			const resetEntity = (await getRes.json()) as { state: string };
 			expect(resetEntity.state).toBe("backlog");
 		});
@@ -439,7 +439,7 @@ describe("E2E: full-stack silo flow", { timeout: 15000 }, () => {
 			expect(validateResult.newState).toBeUndefined();
 
 			// Entity must still be in pending state
-			const getRes = await fetch(`http://127.0.0.1:${ctx.port}/api/entities/${entity.id}`);
+			const getRes = await fetch(`http://127.0.0.1:${ctx.port}/api/entities/${entity.id}`, { headers: workerHeaders() });
 			const pendingEntity = (await getRes.json()) as { state: string };
 			expect(pendingEntity.state).toBe("pending");
 		});

--- a/tests/tenant-isolation.test.ts
+++ b/tests/tenant-isolation.test.ts
@@ -648,8 +648,9 @@ describe("tenant isolation — admin auth downgrade", () => {
     await repos.flows.create({ name: "test-flow", initialState: "s1" });
 
     // Non-admin caller with X-Tenant-Id header → should see default tenant data
+    // (worker token authenticates but is not admin, so tenant downgrade applies)
     const res = await app.request("/api/flows", {
-      headers: { "x-tenant-id": "other-tenant" },
+      headers: { "x-tenant-id": "other-tenant", authorization: "Bearer worker-token" },
     });
     expect(res.status).toBe(200);
     const flows = (await res.json()) as Array<{ name: string }>;

--- a/tests/ws/ws-integration.test.ts
+++ b/tests/ws/ws-integration.test.ts
@@ -85,7 +85,9 @@ describe("WebSocket integration with HTTP server", () => {
 	});
 
 	it("HTTP routes still work with WS attached", async () => {
-		const res = await fetch(`http://127.0.0.1:${port}/api/status`);
+		const res = await fetch(`http://127.0.0.1:${port}/api/status`, {
+			headers: { Authorization: "Bearer worker-tok" },
+		});
 		expect(res.status).toBe(200);
 	});
 


### PR DESCRIPTION
## Summary

- Add `requireWorkerAuth()` to `POST /api/entities`
- Add `requireAdminAuth()` to `PUT /api/flows/:id` and `DELETE /api/flows/:id`
- Add new `requireAuth()` middleware (accepts either worker or admin token) to all read endpoints: `GET /api/status`, `/api/entities`, `/api/entities/:id`, `/api/flows`, `/api/flows/:id`
- `requireAuth()` is needed so admin-authenticated callers can still read endpoints for multi-tenant routing (tenant selection requires admin token in `Authorization` header)
- Update all test files to pass appropriate auth headers

All 1014 tests pass.

## Test plan

- [x] `tsc --noEmit` clean
- [x] All 1014 tests pass (0 failures)
- [x] e2e tests pass with auth headers
- [x] Tenant isolation tests pass (admin + worker auth paths)
- [ ] CI green

Closes WOP-2182, WOP-2183, WOP-2184, WOP-2185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Secure HTTP API endpoints with authentication and update tests accordingly.

New Features:
- Add a shared requireAuth middleware that accepts either worker or admin tokens for protected read endpoints.
- Require worker authentication for POST /api/entities and admin authentication for PUT/DELETE /api/flows/:id.

Enhancements:
- Ensure status, entity, and flow read endpoints now enforce authentication while still supporting multi-tenant routing via admin tokens.

Tests:
- Update HTTP, worker-auth, WebSocket, e2e, and tenant isolation tests to send appropriate worker/admin Authorization headers and validate 401 responses when missing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Bearer token authentication to all unprotected HTTP endpoints
> - Introduces a `requireAuth` middleware in [hono-server.ts](https://github.com/wopr-network/silo/pull/163/files#diff-6df2a1ab9324f5b6645c929a7b3503dc1636fa476eef400fbb67b16ae041b1af) that validates the `Authorization: Bearer` header against either the worker or admin token, returning 401 on mismatch.
> - Applies `requireAuth` to `GET /api/status`, `GET /api/entities`, `GET /api/entities/:id`, `GET /api/flows`, and `GET /api/flows/:id`; `POST /api/entities` uses `requireWorkerAuth`; `PUT` and `DELETE /api/flows/:id` use `requireAdminAuth`.
> - Updates tests across server, e2e, tenant-isolation, and WebSocket suites to supply appropriate auth headers and assert 401 for unauthenticated requests.
> - Risk: all previously open endpoints now reject unauthenticated callers with 401, which is a breaking change for any client not sending a token.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb41586.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced API security by enforcing authentication requirements on status, flows, and entities retrieval endpoints, while preserving existing worker and admin authentication patterns for specific operations.

* **Tests**
  * Updated test suite to include required authentication credentials and headers across status, flows, entities, and integration tests to reflect new authentication enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->