### PR TITLE
test(ingestion): add unit tests for Ingestor class (WOP-2165)

### DIFF
--- a/src/ingestion/ingestor.test.ts
+++ b/src/ingestion/ingestor.test.ts
@@ -13,7 +13,7 @@ function makeEntityMapRepo(overrides: Partial<Record<keyof IEntityMapRepository,
   } as IEntityMapRepository;
 }
 
-function makeSiloClient(overrides: Partial<Record<string, unknown>> = {}): SiloClient {
+function makeSiloClient(overrides: Partial<Record<keyof SiloClient, unknown>> = {}): SiloClient {
   return {
     createEntity: vi.fn().mockResolvedValue({ id: "entity-001" }),
     report: vi.fn().mockResolvedValue({ next_action: "continue", new_state: "working", prompt: null, context: null }),
@@ -104,6 +104,8 @@ describe("Ingestor", () => {
       const ingestor = new Ingestor(repo, silo);
 
       await expect(ingestor.ingest({ sourceId: "linear", type: "new", flowName: "eng" })).rejects.toThrow();
+
+      expect(repo.insertIfAbsent).not.toHaveBeenCalled();
     });
 
     it("rejects payload missing type", async () => {
@@ -112,6 +114,8 @@ describe("Ingestor", () => {
       const ingestor = new Ingestor(repo, silo);
 
       await expect(ingestor.ingest({ sourceId: "linear", externalId: "X", flowName: "eng" })).rejects.toThrow();
+
+      expect(repo.insertIfAbsent).not.toHaveBeenCalled();
     });
 
     it("rejects payload missing flowName", async () => {
@@ -120,6 +124,8 @@ describe("Ingestor", () => {
       const ingestor = new Ingestor(repo, silo);
 
       await expect(ingestor.ingest({ sourceId: "linear", externalId: "X", type: "new" })).rejects.toThrow();
+
+      expect(repo.insertIfAbsent).not.toHaveBeenCalled();
     });
 
     it("rejects payload with invalid type value", async () => {
@@ -135,6 +141,8 @@ describe("Ingestor", () => {
           flowName: "eng",
         }),
       ).rejects.toThrow();
+
+      expect(repo.insertIfAbsent).not.toHaveBeenCalled();
     });
 
     it("rejects empty string sourceId", async () => {
@@ -150,6 +158,8 @@ describe("Ingestor", () => {
           flowName: "eng",
         }),
       ).rejects.toThrow();
+
+      expect(repo.insertIfAbsent).not.toHaveBeenCalled();
     });
 
     it("rejects non-object input", async () => {
@@ -160,6 +170,8 @@ describe("Ingestor", () => {
       await expect(ingestor.ingest("not an object")).rejects.toThrow();
       await expect(ingestor.ingest(null)).rejects.toThrow();
       await expect(ingestor.ingest(42)).rejects.toThrow();
+
+      expect(repo.insertIfAbsent).not.toHaveBeenCalled();
     });
   });
 
@@ -184,6 +196,31 @@ describe("Ingestor", () => {
   });
 
   describe("ingest() — error handling", () => {
+    it("re-throws when updateEntityId succeeds but silo.report fails", async () => {
+      const repo = makeEntityMapRepo();
+      const silo = makeSiloClient({
+        report: vi.fn().mockRejectedValue(new Error("flow.report failed: 503")),
+      });
+      const ingestor = new Ingestor(repo, silo);
+
+      await expect(
+        ingestor.ingest({
+          sourceId: "linear",
+          externalId: "WOP-100",
+          type: "new",
+          flowName: "engineering",
+          signal: "start",
+        }),
+      ).rejects.toThrow("flow.report failed: 503");
+
+      expect(repo.updateEntityId).toHaveBeenCalledWith("linear", "WOP-100", "entity-001");
+      expect(silo.report).toHaveBeenCalledWith({
+        entityId: "entity-001",
+        signal: "start",
+        artifacts: {},
+      });
+    });
+
     it("cleans up sentinel and re-throws when createEntity fails", async () => {
       const repo = makeEntityMapRepo();
       const silo = makeSiloClient({


### PR DESCRIPTION
## Summary
Closes WOP-2165

- Add `src/ingestion/ingestor.test.ts` with 16 unit tests for the `Ingestor` class
- Tests use pure mock dependencies (`vi.fn()`) — no database, no HTTP
- Covers: happy path (new entity + signal), new entity without signal, new entity without payload, validation rejection (missing fields, invalid type, empty sourceId, non-object input), duplicate handling (lost INSERT race), sentinel cleanup on `createEntity` failure, update path (existing entity, default signal, unknown entity, pending entity)

## Test plan
- [x] `npm run check` passes (biome + tsc)
- [x] `npx vitest run src/ingestion/ingestor.test.ts` — 16 tests passed

Generated with Claude Code

## Summary by Sourcery

Tests:
- Add ingestion unit tests for new and update flows, covering validation errors, duplicate races, pending state handling, and error cleanup without hitting external services.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for `Ingestor.ingest()` in the ingestion pipeline
> Adds a Vitest test suite in [ingestor.test.ts](https://github.com/wopr-network/silo/pull/169/files#diff-91ada81a9ce59e51f15c9794aa8058b06252086cea97e08fae5c36e81b14c315) covering the full behavior of `Ingestor.ingest()`.
>
> - Tests the 'new' ingestion path: entity creation, sentinel updates, optional signal/report skipping, and payload omission
> - Tests validation failures for missing/invalid fields and non-object input
> - Tests duplicate handling when `insertIfAbsent` returns false
> - Tests error handling for `createEntity`/report failures, including sentinel cleanup
> - Tests the 'update' path: reporting with payload, defaulting signal to `'update'`, skipping when entity not found, and erroring when entity is `'__pending__'`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 146d584.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->