### PR TITLE
fix: major-version detection in dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -52,7 +52,6 @@ jobs:
 
       - name: Enable auto-merge
         if: steps.meta.outputs.skip != 'true'
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh pr merge --auto --squash ${{ steps.meta.outputs.pr_number }}


### PR DESCRIPTION
## Summary
- Fix broken semver regex that caused major version bumps to be auto-merged
- Replace `|| true` with `continue-on-error: true` for visible failure logging

## Root cause
The regex `/from \d+ to \d+/` never matches semver titles like "Bump foo from 1.2.3 to 2.0.0" because `\d+` stops at the dot. Result: `isMajor` was always `false`, all bumps including major were auto-merged.

## Fix
Extract major version with `/from (\d+)\.\d/` and `/to (\d+)\.\d/`, compare those.

Flagged by: Devin, Greptile, Copilot, Sourcery

## Summary by Sourcery

Correct Dependabot auto-merge behavior to avoid automatically merging major version upgrades and surface merge command failures.

Bug Fixes:
- Fix major-version detection in Dependabot PR titles so that major bumps are no longer auto-merged.

Enhancements:
- Improve Dependabot auto-merge workflow logging by allowing merge command failures to be reported instead of silently ignored.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix major-version detection in dependabot auto-merge workflow
> - Replaces loose pattern matching with explicit regex capture groups (`from (\d+)\.\d` and `to (\d+)\.\d`) in [dependabot-auto-merge.yml](.github/workflows/dependabot-auto-merge.yml) to correctly identify major version bumps.
> - A PR is only marked as major (and skipped) when both from/to major versions are present and differ; previously, ambiguous matches could incorrectly skip or approve PRs.
> - Removes `|| true` from the `gh pr merge` command so merge failures now surface as step failures instead of being silently swallowed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d515e90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->