### PR TITLE
fix: log swallowed error in run-loop crash report signal (WOP-2174)

### DIFF
--- a/src/run-loop/run-loop.test.ts
+++ b/src/run-loop/run-loop.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Dispatcher, WorkerResult } from "../dispatcher/types.js";
 import { logger } from "../logger.js";
 import { Pool } from "../pool/pool.js";
@@ -248,8 +248,14 @@ describe("RunLoop — multi-discipline routing", () => {
 });
 
 describe("RunLoop — crash report logging", () => {
-  it("logs warning when crash report fails after slot allocation failure", async () => {
-    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    errorSpy?.mockRestore();
+  });
+
+  it("logs error when crash report fails after slot allocation failure", async () => {
+    errorSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
 
     const firstClaim = {
       entity_id: "e-crash",
@@ -275,11 +281,9 @@ describe("RunLoop — crash report logging", () => {
     await vi.waitFor(() => expect(silo.report).toHaveBeenCalledTimes(1), { timeout: 3000 });
     await loop.stop();
 
-    expect(warnSpy).toHaveBeenCalledWith(
+    expect(errorSpy).toHaveBeenCalledWith(
       "[run-loop] failed to report crash signal",
       expect.objectContaining({ error: "DB connection lost" }),
     );
-
-    warnSpy.mockRestore();
   });
 });

--- a/src/run-loop/run-loop.ts
+++ b/src/run-loop/run-loop.ts
@@ -231,7 +231,7 @@ export class RunLoop {
           artifacts: { error: "slot unavailable" },
         });
       } catch (err) {
-        logger.warn("[run-loop] failed to report crash signal", { error: safeErrorMessage(err) });
+        logger.error("[run-loop] failed to report crash signal", { error: safeErrorMessage(err) });
       }
       await sleep(this.pollIntervalMs, this.signal);
       return;


### PR DESCRIPTION
## Summary
Closes WOP-2174

- Replaced empty `catch {}` at `src/run-loop/run-loop.ts:233` with a `logger.warn` call so crash report failures are visible in logs
- Pattern matches the existing `logger.error` at line 218 for the per-repo concurrency crash path
- Added Vitest test verifying the warn is called when `silo.report()` rejects after slot allocation failure

## Test plan
- [x] `npm run check` passes (biome + tsc)
- [x] `npx vitest run src/run-loop/run-loop.test.ts` — all 7 tests pass including new "crash report logging" test

Generated with Claude Code

## Summary by Sourcery

Log failures when emitting run-loop crash reports to ensure errors are surfaced instead of silently swallowed.

Bug Fixes:
- Log a warning when crash report emission fails after a slot allocation failure instead of silently ignoring the error.

Tests:
- Add a test ensuring a warning is logged when the crash report path rejects after a slot allocation failure.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log swallowed error in run-loop crash report signal handler
> In [run-loop.ts](https://github.com/wopr-network/silo/pull/173/files#diff-fc651dc57b130c0872d2da183f2811a38eae0d9dc939c3986ba8709e58f4e68f), the empty `catch` block around `silo.report({ signal: "crash" })` now logs `"[run-loop] failed to report crash signal"` with the error message via `logger.error` instead of silently discarding the failure. A test suite in [run-loop.test.ts](https://github.com/wopr-network/silo/pull/173/files#diff-6e1d169486903a28b3f4022232860fe541760845e1f893ac67c8b9b476b51b36) verifies the logging by using a zero-capacity pool to trigger the crash path and a mock engine whose `report()` rejects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 066a79a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->