### PR TITLE
test: add tests for sources/validation.ts (WOP-2167)

### DIFF
--- a/tests/sources/validation.test.ts
+++ b/tests/sources/validation.test.ts
@@ -124,13 +124,19 @@ describe("getWorktreeBase", () => {
 
 describe("validateWorktreePath", () => {
   const testBase = "/tmp/test-worktrees";
+  let originalWorktreeDir: string | undefined;
 
   beforeEach(() => {
-    vi.unstubAllEnvs();
+    originalWorktreeDir = process.env.WORKTREE_DIR;
+    delete process.env.WORKTREE_DIR;
   });
 
   afterEach(() => {
-    vi.unstubAllEnvs();
+    if (originalWorktreeDir === undefined) {
+      delete process.env.WORKTREE_DIR;
+    } else {
+      process.env.WORKTREE_DIR = originalWorktreeDir;
+    }
   });
 
   it("returns resolved path when target is within base", () => {


### PR DESCRIPTION
## Summary
Closes WOP-2167

- Add `tests/sources/validation.test.ts` with 31 test cases for `src/sources/validation.ts`
- Tests cover `BRANCH_NAME_REGEX` (8 cases), `validateBranchName` (7 cases), `getWorktreeBase` (4 cases with env save/restore), and `validateWorktreePath` (12 cases)
- Includes critical edge cases: double-dot path traversal rejection, prefix-collision attack (`/tmp/test-worktrees-evil`), env var isolation between tests

## Test plan
- [ ] `npm run check` passes (biome + tsc)
- [ ] `npx vitest run tests/sources/validation.test.ts` — 31/31 pass

Generated with Claude Code

## Summary by Sourcery

Add comprehensive unit tests for source validation utilities.

Tests:
- Add coverage for branch name regex and validateBranchName behavior across valid and invalid cases.
- Add tests for getWorktreeBase including environment variable isolation and restoration.
- Add tests for validateWorktreePath including path traversal and prefix-collision edge cases.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for `BRANCH_NAME_REGEX`, `validateBranchName`, `getWorktreeBase`, and `validateWorktreePath` in sources/validation
> Adds a new test file [validation.test.ts](https://github.com/wopr-network/silo/pull/175/files#diff-2e9dfb8289c8ebbc671e216b7ae5fc46f950dd2430b1b8ee7c6e103cc55809a0) covering the four main exports of `sources/validation.ts`.
>
> - `BRANCH_NAME_REGEX`: asserts valid patterns (slashes, dots, hyphens) and rejects double dots, spaces, and special characters
> - `validateBranchName`: confirms valid names pass through unchanged and invalid names throw with an error message containing the input and regex string
> - `getWorktreeBase`: verifies resolution against `WORKTREE_DIR` (absolute and relative) and fallback to `./worktrees` when unset
> - `validateWorktreePath`: covers acceptance of in-base paths (nested, equal) and rejection of path traversal, sibling, prefix-only, and parent paths, including error message content and default base behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77b2112.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for branch name validation and worktree path handling, covering valid/invalid input scenarios, edge cases, error handling, and path resolution to enhance code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->