### PR TITLE
test: add tests for silo REST client (WOP-2168)

### DIFF
--- a/tests/silo-client/client.test.ts
+++ b/tests/silo-client/client.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { SiloClient } from "../../src/silo-client/client.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockFetchOk(body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  });
+}
+
+function mockFetchError(status: number) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: "fail" }),
+  });
+}
+
+describe("SiloClient", () => {
+  const BASE = "http://localhost:3001";
+
+  describe("constructor", () => {
+    it("sets auth header when workerToken is provided", async () => {
+      const client = new SiloClient({ url: BASE, workerToken: "tok-123" });
+      const claimBody = { next_action: "check_back", retry_after_ms: 1000, message: "none" };
+      const fetchMock = mockFetchOk(claimBody);
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.claim({ role: "coder" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer tok-123" }),
+        }),
+      );
+    });
+
+    it("omits auth header when workerToken is not provided", async () => {
+      const client = new SiloClient({ url: BASE });
+      const claimBody = { next_action: "check_back", retry_after_ms: 1000, message: "none" };
+      const fetchMock = mockFetchOk(claimBody);
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.claim({ role: "coder" });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(opts.headers).toEqual({ "Content-Type": "application/json" });
+    });
+  });
+
+  describe("claim()", () => {
+    it("POSTs to /api/claim with role in body", async () => {
+      const client = new SiloClient({ url: BASE, workerToken: "tok" });
+      const body = {
+        entity_id: "e-1",
+        invocation_id: "inv-1",
+        flow: "f",
+        stage: "s",
+        prompt: "p",
+        context: null,
+      };
+      const fetchMock = mockFetchOk(body);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await client.claim({ role: "coder" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE}/api/claim`,
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: "Bearer tok" },
+          body: JSON.stringify({ role: "coder" }),
+        }),
+      );
+      expect(result).toEqual(body);
+    });
+
+    it("POSTs to /api/flows/{flow}/claim when flow is provided", async () => {
+      const client = new SiloClient({ url: BASE, workerToken: "tok" });
+      const body = { next_action: "check_back", retry_after_ms: 5000, message: "wait" };
+      const fetchMock = mockFetchOk(body);
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.claim({ role: "architect", flow: "my-flow" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE}/api/flows/my-flow/claim`,
+        expect.any(Object),
+      );
+    });
+
+    it("URL-encodes flow name with special characters", async () => {
+      const client = new SiloClient({ url: BASE });
+      const fetchMock = mockFetchOk({
+        next_action: "check_back",
+        retry_after_ms: 1000,
+        message: "wait",
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.claim({ role: "coder", flow: "flow/with spaces" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE}/api/flows/flow%2Fwith%20spaces/claim`,
+        expect.any(Object),
+      );
+    });
+
+    it("passes abort signal from opts", async () => {
+      const client = new SiloClient({ url: BASE });
+      const fetchMock = mockFetchOk({
+        next_action: "check_back",
+        retry_after_ms: 1000,
+        message: "wait",
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const controller = new AbortController();
+      await client.claim({ role: "coder" }, { signal: controller.signal });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: controller.signal }),
+      );
+    });
+
+    it("deserializes check_back response", async () => {
+      const client = new SiloClient({ url: BASE });
+      const body = {
+        next_action: "check_back" as const,
+        retry_after_ms: 30000,
+        message: "no work",
+      };
+      vi.stubGlobal("fetch", mockFetchOk(body));
+
+      const result = await client.claim({ role: "coder" });
+      expect(result).toEqual(body);
+    });
+
+    it("throws on 4xx response", async () => {
+      const client = new SiloClient({ url: BASE });
+      vi.stubGlobal("fetch", mockFetchError(403));
+
+      await expect(client.claim({ role: "coder" })).rejects.toThrow("flow.claim failed: 403");
+    });
+
+    it("throws on 5xx response", async () => {
+      const client = new SiloClient({ url: BASE });
+      vi.stubGlobal("fetch", mockFetchError(500));
+
+      await expect(client.claim({ role: "coder" })).rejects.toThrow("flow.claim failed: 500");
+    });
+
+    it("throws on network error", async () => {
+      const client = new SiloClient({ url: BASE });
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("fetch failed")));
+
+      await expect(client.claim({ role: "coder" })).rejects.toThrow("fetch failed");
+    });
+  });
+
+  describe("createEntity()", () => {
+    it("POSTs to /api/entities with flow mapped from flowName", async () => {
+      const client = new SiloClient({ url: BASE, workerToken: "tok" });
+      const fetchMock = mockFetchOk({ id: "ent-1" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await client.createEntity({ flowName: "my-flow" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE}/api/entities`,
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: "Bearer tok" },
+          body: JSON.stringify({ flow: "my-flow" }),
+        }),
+      );
+      expect(result).toEqual({ id: "ent-1" });
+    });
+
+    it("includes payload when provided", async () => {
+      const client = new SiloClient({ url: BASE });
+      const fetchMock = mockFetchOk({ id: "ent-2" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.createEntity({ flowName: "f", payload: { key: "val" } });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toEqual({ flow: "f", payload: { key: "val" } });
+    });
+
+    it("omits payload key when payload is undefined", async () => {
+      const client = new SiloClient({ url: BASE });
+      const fetchMock = mockFetchOk({ id: "ent-3" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.createEntity({ flowName: "f" });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toEqual({ flow: "f" });
+      expect("payload" in body).toBe(false);
+    });
+
+    it("applies AbortSignal.timeout to fetch", async () => {
+      const client = new SiloClient({ url: BASE });
+      const fetchMock = mockFetchOk({ id: "ent-4" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.createEntity({ flowName: "f" });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(opts.signal).toBeDefined();
+      expect(opts.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("throws on 4xx response", async () => {
+      const client = new SiloClient({ url: BASE });
+      vi.stubGlobal("fetch", mockFetchError(422));
+
+      await expect(client.createEntity({ flowName: "f" })).rejects.toThrow(
+        "entity create failed: 422",
+      );
+    });
+
+    it("throws on 5xx response", async () => {
+      const client = new SiloClient({ url: BASE });
+      vi.stubGlobal("fetch", mockFetchError(503));
+
+      await expect(client.createEntity({ flowName: "f" })).rejects.toThrow(
+        "entity create failed: 503",
+      );
+    });
+
+    it("throws on network error", async () => {
+      const client = new SiloClient({ url: BASE });
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+      await expect(client.createEntity({ flowName: "f" })).rejects.toThrow("Failed to fetch");
+    });
+  });
+
+  describe("report()", () => {
+    it("POSTs to /api/entities/{id}/report with signal in body", async () => {
+      const client = new SiloClient({ url: BASE, workerToken: "tok" });
+      const responseBody = {
+        next_action: "continue",
+        new_state: "reviewing",
+        prompt: "review it",
+        context: null,
+      };
+      const fetchMock = mockFetchOk(responseBody);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await client.report({ entityId: "ent-42", signal: "spec_ready" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE}/api/entities/ent-42/report`,
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: "Bearer tok" },
+          body: JSON.stringify({ signal: "spec_ready" }),
+        }),
+      );
+      expect(result).toEqual(responseBody);
+    });
+
+    it("URL-encodes entityId", async () => {
+      const client = new SiloClient({ url: BASE });
+      const fetchMock = mockFetchOk({
+        next_action: "completed",
+        new_state: "done",
+        prompt: null,
+        context: null,
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.report({ entityId: "ent/special id", signal: "done" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE}/api/entities/ent%2Fspecial%20id/report`,
+        expect.any(Object),
+      );
+    });
+
+    it("includes artifacts when provided", async () => {
+      const client = new SiloClient({ url: BASE });
+      const fetchMock = mockFetchOk({
+        next_action: "continue",
+        new_state: "s",
+        prompt: "p",
+        context: null,
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.report({
+        entityId: "e-1",
+        signal: "done",
+        artifacts: { pr_url: "https://gh.com/1" },
+      });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toEqual({ signal: "done", artifacts: { pr_url: "https://gh.com/1" } });
+    });
+
+    it("omits artifacts and worker_id keys when not provided", async () => {
+      const client = new SiloClient({ url: BASE });
+      const fetchMock = mockFetchOk({
+        next_action: "continue",
+        new_state: "s",
+        prompt: "p",
+        context: null,
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.report({ entityId: "e-1", signal: "done" });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toEqual({ signal: "done" });
+      expect("artifacts" in body).toBe(false);
+      expect("worker_id" in body).toBe(false);
+    });
+
+    it("maps workerId (camelCase) to worker_id (snake_case) in body", async () => {
+      const client = new SiloClient({ url: BASE });
+      const fetchMock = mockFetchOk({
+        next_action: "continue",
+        new_state: "s",
+        prompt: "p",
+        context: null,
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.report({ entityId: "e-1", signal: "done", workerId: "w-7" });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.worker_id).toBe("w-7");
+      expect("workerId" in body).toBe(false);
+    });
+
+    it("passes abort signal from opts", async () => {
+      const client = new SiloClient({ url: BASE });
+      const fetchMock = mockFetchOk({
+        next_action: "completed",
+        new_state: "done",
+        prompt: null,
+        context: null,
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const controller = new AbortController();
+      await client.report({ entityId: "e-1", signal: "done" }, { signal: controller.signal });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: controller.signal }),
+      );
+    });
+
+    it("throws on 4xx response", async () => {
+      const client = new SiloClient({ url: BASE });
+      vi.stubGlobal("fetch", mockFetchError(404));
+
+      await expect(client.report({ entityId: "e-1", signal: "done" })).rejects.toThrow(
+        "flow.report failed: 404",
+      );
+    });
+
+    it("throws on 5xx response", async () => {
+      const client = new SiloClient({ url: BASE });
+      vi.stubGlobal("fetch", mockFetchError(502));
+
+      await expect(client.report({ entityId: "e-1", signal: "done" })).rejects.toThrow(
+        "flow.report failed: 502",
+      );
+    });
+
+    it("throws on network error", async () => {
+      const client = new SiloClient({ url: BASE });
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("network down")));
+
+      await expect(client.report({ entityId: "e-1", signal: "done" })).rejects.toThrow(
+        "network down",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-2168

- Creates `tests/silo-client/client.test.ts` with 26 tests covering the full `SiloClient` surface
- Uses `vi.stubGlobal("fetch", ...)` pattern consistent with the repo's existing test style
- Tests request construction, response deserialization, HTTP error handling, and network failure handling

### Coverage

| Group | Count |
|-------|-------|
| constructor (auth header present/absent) | 2 |
| `claim()` URL routing (base vs flow-specific) | 2 |
| `claim()` URL encoding of flow name | 1 |
| `claim()` abort signal passthrough | 1 |
| `claim()` response deserialization | 1 |
| `claim()` 4xx/5xx/network errors | 3 |
| `createEntity()` flowName→flow key mapping | 1 |
| `createEntity()` payload present/absent | 2 |
| `createEntity()` AbortSignal.timeout applied | 1 |
| `createEntity()` 4xx/5xx/network errors | 3 |
| `report()` URL + body construction | 1 |
| `report()` URL encoding of entityId | 1 |
| `report()` artifacts inclusion/omission | 2 |
| `report()` workerId→worker_id mapping | 1 |
| `report()` abort signal passthrough | 1 |
| `report()` 4xx/5xx/network errors | 3 |

## Test plan
- [x] `npm run check` passes (biome + tsc --noEmit)
- [x] `npx vitest run tests/silo-client/` passes (26/26 tests)

Generated with Claude Code

## Summary by Sourcery

Add comprehensive test coverage for the SiloClient REST client interactions with the silo API.

Tests:
- Add vitest coverage for SiloClient constructor auth header behavior.
- Cover SiloClient.claim request routing, payload construction, URL encoding, abort handling, response parsing, and error cases.
- Cover SiloClient.createEntity request body construction, flowName mapping, timeout behavior, and HTTP/network error handling.
- Cover SiloClient.report endpoint URL encoding, request body mapping (including artifacts and workerId), abort handling, and HTTP/network error handling.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for silo REST client covering `SiloClient` constructor, `claim()`, `createEntity()`, and `report()`
> Adds a comprehensive test suite in [client.test.ts](https://github.com/wopr-network/silo/pull/179/files#diff-cbfc5367a66925feb40a0e9f471c651b5ddc6d137460fb80ba8c03cdcc8175bf) for the silo REST client. Tests cover request construction (headers, URL encoding, JSON body mapping), `AbortSignal` propagation, response deserialization, and error handling for 4xx, 5xx, and network failures. Introduces `mockFetchOk` and `mockFetchError` helpers and a global `afterEach` hook to reset stubbed globals via `vi.unstubAllGlobals()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be2065b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->