### PR TITLE
ci: split tests into separate job on test-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,23 @@ name: CI
 
 on:
   merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
-  ci:
+  lint-check:
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: read
-      pull-requests: write
-    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
 
@@ -30,8 +34,41 @@ jobs:
       - name: Lint and Type Check
         run: pnpm check
 
+  build:
+    runs-on: [self-hosted, Linux, X64]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Build
         run: pnpm build
+
+  unit-test:
+    runs-on: [self-hosted, Linux, X64, test-runner]
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
 
       - name: Test
         run: pnpm test -- --coverage
@@ -41,3 +78,17 @@ jobs:
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           json-summary-path: coverage/coverage-summary.json
+
+  ci:
+    if: always()
+    needs: [lint-check, build, unit-test]
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - name: Check results
+        run: |
+          if [ "${{ needs.lint-check.result }}" != "success" ] || \
+             [ "${{ needs.build.result }}" != "success" ] || \
+             [ "${{ needs.unit-test.result }}" != "success" ]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Split monolithic `ci` job into `lint-check`, `build`, and `unit-test` jobs
- Tests now run on `[self-hosted, Linux, X64, test-runner]` to avoid OOM on standard runner
- Summary `ci` job gates the merge queue as before (preserves branch protection)

## Test plan
- [ ] `lint-check` job passes on self-hosted runner
- [ ] `build` job passes on self-hosted runner
- [ ] `unit-test` job passes on test-runner
- [ ] `ci` summary job passes after all three succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Split the CI workflow into dedicated lint, build, and unit-test jobs with a final aggregate CI gate job.

CI:
- Add separate GitHub Actions jobs for lint/type-check, build, and unit tests instead of a single monolithic CI job.
- Run unit tests on a dedicated self-hosted test-runner label to mitigate resource issues on standard runners.
- Introduce workflow-level concurrency to cancel in-progress runs of the same ref and avoid redundant CI executions.
- Add a summary CI job that depends on all other jobs and fails if any constituent job does not succeed, preserving merge protection behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split CI workflow into separate lint, build, and test jobs on dedicated test-runner
> - Replaces the single monolithic `ci` job in [ci.yml](.github/workflows/ci.yml) with three parallel jobs: `lint-check`, `build`, and `unit-test`, plus an aggregator `ci` job that fails if any upstream job fails.
> - The `unit-test` job runs on the `test-runner` self-hosted runner and retains `pull-requests: write` for posting coverage reports; `lint-check` and `build` run with `contents: read` only.
> - Adds concurrency controls to cancel in-progress runs for the same ref, and adds a `merge_group: checks_requested` trigger.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e97276.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure. Restructured job pipeline with improved concurrency handling and separated build, lint, and test processes for better reliability and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->