### PR TITLE
fix: add model_tier and agent_role to ClaimResponse, remove unsafe casts (WOP-2181)

### DIFF
--- a/src/api/wire-types.ts
+++ b/src/api/wire-types.ts
@@ -16,6 +16,8 @@ export type ClaimResponse =
       stage: string;
       prompt: string;
       context: Record<string, unknown> | null;
+      model_tier?: string;
+      agent_role?: string;
       worker_notice?: string;
     };
 

--- a/src/run-loop/run-loop.test.ts
+++ b/src/run-loop/run-loop.test.ts
@@ -247,6 +247,65 @@ describe("RunLoop — multi-discipline routing", () => {
   });
 });
 
+describe("RunLoop — model_tier and agent_role from claim", () => {
+  it("passes model_tier from claim to dispatcher", async () => {
+    const firstClaim = {
+      entity_id: "e-tier",
+      invocation_id: "inv-1",
+      prompt: "Do the work",
+      flow: "engineering",
+      stage: "coding",
+      context: null,
+      model_tier: "opus",
+      agent_role: "coder",
+    };
+
+    const dispatcher = makeDispatcher({ signal: "pr_created", artifacts: {}, exitCode: 0 });
+    const silo = {
+      claim: vi.fn().mockResolvedValueOnce(firstClaim).mockResolvedValue({ retry_after_ms: 50 }),
+      report: vi.fn().mockResolvedValue({ next_action: "done" }),
+    } as unknown as import("../engine/flow-engine-interface.js").IFlowEngine;
+
+    const config = makeConfig({ pool: new Pool(1), engine: silo, dispatcher });
+    const loop = new RunLoop(config);
+    loop.start();
+
+    await vi.waitFor(() => expect(dispatcher.dispatch).toHaveBeenCalledTimes(1), { timeout: 3000 });
+    await loop.stop();
+
+    const opts = vi.mocked(dispatcher.dispatch).mock.calls[0]?.[1];
+    expect(opts?.modelTier).toBe("opus");
+    expect(opts?.agentRole).toBe("coder");
+  });
+
+  it("defaults model_tier to sonnet when not present in claim", async () => {
+    const firstClaim = {
+      entity_id: "e-default",
+      invocation_id: "inv-2",
+      prompt: "Do the work",
+      flow: "engineering",
+      stage: "coding",
+      context: null,
+    };
+
+    const dispatcher = makeDispatcher({ signal: "done", artifacts: {}, exitCode: 0 });
+    const silo = {
+      claim: vi.fn().mockResolvedValueOnce(firstClaim).mockResolvedValue({ retry_after_ms: 50 }),
+      report: vi.fn().mockResolvedValue({ next_action: "done" }),
+    } as unknown as import("../engine/flow-engine-interface.js").IFlowEngine;
+
+    const config = makeConfig({ pool: new Pool(1), engine: silo, dispatcher });
+    const loop = new RunLoop(config);
+    loop.start();
+
+    await vi.waitFor(() => expect(dispatcher.dispatch).toHaveBeenCalledTimes(1), { timeout: 3000 });
+    await loop.stop();
+
+    const opts = vi.mocked(dispatcher.dispatch).mock.calls[0]?.[1];
+    expect(opts?.modelTier).toBe("sonnet");
+  });
+});
+
 describe("RunLoop — crash report logging", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 

--- a/src/run-loop/run-loop.ts
+++ b/src/run-loop/run-loop.ts
@@ -197,7 +197,7 @@ export class RunLoop {
     logger.info(`[radar] slot ${slotId} claimed entity`, {
       entity: claim.entity_id,
       flow: claim.flow ?? "none",
-      stage: (claim as Record<string, unknown>).stage ?? "?",
+      stage: claim.stage ?? "?",
     });
 
     const claimFlow = claim.flow;
@@ -238,14 +238,13 @@ export class RunLoop {
     }
 
     try {
-      const claimAny = claim as Record<string, unknown>;
-      const rawModelTier = (claimAny.model_tier as string | undefined) ?? "sonnet";
+      const rawModelTier = claim.model_tier ?? "sonnet";
       let modelTier: "opus" | "sonnet" | "haiku" =
         rawModelTier === "opus" || rawModelTier === "haiku" ? rawModelTier : "sonnet";
       // agentRole can be overridden by `continue` responses (e.g. when the engine
       // routes to a different state with a different role). If not overridden, the
       // original role from the claim is kept.
-      let agentRole = (claimAny.agent_role as string | null | undefined) ?? null;
+      let agentRole = claim.agent_role ?? null;
       const originalPrompt = claim.prompt;
       let currentPrompt = claim.prompt;
       let currentSignal: string | undefined;
@@ -270,7 +269,7 @@ export class RunLoop {
               workerId,
               entityId: claim.entity_id,
               agentRole,
-              templateContext: ((claim as Record<string, unknown>).context as Record<string, unknown> | null) ?? null,
+              templateContext: claim.context,
             });
             logger.info(`[radar] slot ${slotId} dispatch done`, {
               signal: result.signal,
@@ -339,25 +338,23 @@ export class RunLoop {
           currentPrompt = activityHistory ? `${activityHistory}\n\n---\n${basePrompt}` : basePrompt;
           // Update templateContext from the engine so the next dispatch uses fresh context
           if ("context" in response && response.context != null) {
-            (claim as Record<string, unknown>).context = response.context;
+            claim.context = response.context;
           }
           // Update model tier and agent role from the new state, resetting to
           // defaults when the continue response omits them.
-          const resp = response as Record<string, unknown>;
           const newTier =
-            typeof resp.model_tier === "string" &&
-            (resp.model_tier === "opus" || resp.model_tier === "sonnet" || resp.model_tier === "haiku")
-              ? resp.model_tier
+            response.model_tier === "opus" || response.model_tier === "sonnet" || response.model_tier === "haiku"
+              ? response.model_tier
               : "sonnet";
           if (newTier !== modelTier) {
             logger.info(`[radar] slot ${slotId} model tier changed`, {
               from: modelTier,
               to: newTier,
-              newState: resp.new_state,
+              newState: response.new_state,
             });
             modelTier = newTier;
           }
-          agentRole = typeof resp.agent_role === "string" ? resp.agent_role : null;
+          agentRole = response.agent_role ?? null;
           currentSignal = undefined;
           currentArtifacts = undefined;
           continue;


### PR DESCRIPTION
## Summary
Closes WOP-2181

- Add `model_tier?` and `agent_role?` to the work-claim variant of `ClaimResponse` in `src/api/wire-types.ts`
- Remove all 5 unsafe `as Record<string, unknown>` casts in `src/run-loop/run-loop.ts` that bypassed type checking
- Remove the `resp` cast for `ReportResponse` in the `continue` branch (already narrowed by discriminant)
- Add two tests verifying `model_tier` and `agent_role` from claim are passed through to dispatcher

## Test plan
- [x] `npm run check` passes (biome + tsc --noEmit)
- [x] `npx vitest run src/run-loop/run-loop.test.ts` passes (9 tests)

Generated with Claude Code

## Summary by Sourcery

Propagate model tier and agent role from work claims through the run loop while tightening type safety.

New Features:
- Allow ClaimResponse work-claim payloads to optionally include model_tier and agent_role and surface them to the dispatcher.

Bug Fixes:
- Ensure dispatcher options correctly reflect model tier and agent role from claims, defaulting the model tier to sonnet when absent.

Enhancements:
- Remove unsafe Record<string, unknown> casts in the run loop in favor of typed access to claim and response fields.

Tests:
- Add run loop tests verifying that model_tier and agent_role from claims are forwarded to the dispatcher and that model_tier defaults to sonnet when omitted.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `model_tier` and `agent_role` to `ClaimResponse` and remove unsafe casts in run loop
> - Extends the `ClaimResponse` wire type with optional `model_tier` and `agent_role` fields in [wire-types.ts](https://github.com/wopr-network/silo/pull/183/files#diff-3daf581caddfa5575f33227ff2e3ce0d014eb40046dc314ec5719e819f63212d).
> - Updates the slot worker loop in [run-loop.ts](https://github.com/wopr-network/silo/pull/183/files#diff-fc651dc57b130c0872d2da183f2811a38eae0d9dc939c3986ba8709e58f4e68f) to read these fields via typed property access instead of unsafe casts, defaulting `model_tier` to `'sonnet'` when absent.
> - Adds tests verifying that `model_tier` and `agent_role` from the claim are correctly forwarded to dispatcher options as `modelTier` and `agentRole`.
>
> #### 🖇️ Linked Issues
> [WOP-2181](https://linear.app/wopr/issue/WOP-2181)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36a1185.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->