### PR TITLE
test: remove dead TestDb import from schema.test.ts (WOP-2172)

### DIFF
--- a/tests/repositories/drizzle/schema.test.ts
+++ b/tests/repositories/drizzle/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { getTableName } from "drizzle-orm";
 import * as schema from "../../../src/repositories/drizzle/schema.js";
-import { createTestDb, type TestDb } from "../../helpers/pg-test-db.js";
+import { createTestDb } from "../../helpers/pg-test-db.js";
 
 describe("schema tables exist", () => {
   it("exports flowDefinitions table", () => {


### PR DESCRIPTION
## Summary
Closes WOP-2172

- Remove unused `type TestDb` import specifier from `tests/repositories/drizzle/schema.test.ts` line 4
- `createTestDb` is still used and retained; only the dead type import is removed

## Test plan
- [ ] `npm run check` passes (biome + tsc)
- [ ] No regressions in schema test file

Generated with Claude Code

## Summary by Sourcery

Chores:
- Clean up an unused TestDb type import in tests/repositories/drizzle/schema.test.ts without affecting existing test behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `TestDb` import from `schema.test.ts`
> Removes the dead type-only import `TestDb` from [schema.test.ts](https://github.com/wopr-network/silo/pull/185/files#diff-0497148503dc2a79ee3cfabf686bb3f9b106aa9bba435ca32858f427a7751d76), leaving only the used `createTestDb` import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c346bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->