### PR TITLE
test: replace hardcoded dates with relative dates (WOP-2171)

### DIFF
--- a/tests/execution/mcp-server.test.ts
+++ b/tests/execution/mcp-server.test.ts
@@ -690,7 +690,7 @@ describe("MCP tool handlers", () => {
   // Finding 1 (round 4): flow.report must clear gate_failures on successful transition
   it("flow.report clears gate_failures after successful transition", async () => {
     deps.entities.get = async () =>
-      mockEntity({ artifacts: { gate_failures: [{ gateId: "g-1", failedAt: "2024-01-01" }], other: "preserved" } });
+      mockEntity({ artifacts: { gate_failures: [{ gateId: "g-1", failedAt: new Date(Date.now() - 86_400_000).toISOString() }], other: "preserved" } });
     const updateArtifactsCalls: Array<Record<string, unknown>> = [];
     deps.entities.updateArtifacts = async (_id, artifacts) => {
       updateArtifactsCalls.push(artifacts as Record<string, unknown>);

--- a/tests/repositories/drizzle/transition-log.repo.test.ts
+++ b/tests/repositories/drizzle/transition-log.repo.test.ts
@@ -91,9 +91,10 @@ describe("DrizzleTransitionLogRepository", () => {
 
   describe("historyFor", () => {
     it("returns history ordered by timestamp ascending", async () => {
-      const t1 = new Date("2026-01-01T00:00:00Z");
-      const t2 = new Date("2026-01-01T01:00:00Z");
-      const t3 = new Date("2026-01-01T02:00:00Z");
+      const now = Date.now();
+      const t1 = new Date(now - 3 * 3_600_000);
+      const t2 = new Date(now - 2 * 3_600_000);
+      const t3 = new Date(now - 1 * 3_600_000);
 
       // Insert out of order to verify sorting
       await repo.record({
@@ -189,7 +190,7 @@ describe("DrizzleTransitionLogRepository", () => {
     });
 
     it("round-trips timestamp through epoch storage", async () => {
-      const ts = new Date("2026-03-07T12:34:56.000Z");
+      const ts = new Date(Date.now() - 86_400_000);
       await repo.record({
         entityId: entityId1,
         fromState: "a",

--- a/tests/ui/sse.test.ts
+++ b/tests/ui/sse.test.ts
@@ -31,7 +31,7 @@ describe("HonoSseAdapter", () => {
       entityId: "e1",
       flowId: "f1",
       payload: {},
-      emittedAt: new Date("2026-01-01"),
+      emittedAt: new Date(),
     });
 
     expect(ctrl.chunks.length).toBe(1);
@@ -64,7 +64,7 @@ describe("HonoSseAdapter", () => {
       entityId: "e1",
       flowId: "f1",
       payload: {},
-      emittedAt: new Date("2026-01-01"),
+      emittedAt: new Date(),
     });
 
     // Controller should be removed after error


### PR DESCRIPTION
## Summary
Closes WOP-2171

- Replaced `"2024-01-01"` ISO string with `new Date(Date.now() - 86_400_000).toISOString()` in `mcp-server.test.ts`
- Replaced three sequential hardcoded `Date` objects in `transition-log.repo.test.ts` with relative offsets (3h, 2h, 1h ago) to preserve ordering
- Replaced round-trip test date in `transition-log.repo.test.ts` with `new Date(Date.now() - 86_400_000)`
- Replaced two `new Date("2026-01-01")` fixture dates in `sse.test.ts` with `new Date()`

## Test plan
- [x] `npm run check` passes (biome + tsc)
- [x] `npx vitest run tests/execution/mcp-server.test.ts tests/repositories/drizzle/transition-log.repo.test.ts tests/ui/sse.test.ts` — 110 tests pass

Generated with Claude Code

## Summary by Sourcery

Update tests to use relative, time-based dates instead of hardcoded future timestamps.

Enhancements:
- Make timestamp-dependent tests resilient to real-world dates by switching from fixed future dates to values derived from the current time.

Tests:
- Adjust transition-log repository tests to use relative hour offsets while preserving ordering semantics.
- Update SSE adapter tests to emit events using the current time instead of fixed future dates.
- Update MCP server tests to use a relative ISO timestamp for gate failure artifacts instead of a fixed calendar date.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace hardcoded dates with relative dates in test fixtures
> Fixes tests that would eventually fail as hardcoded timestamps age out of valid ranges. Affected tests in [mcp-server.test.ts](https://github.com/wopr-network/silo/pull/188/files#diff-8fead31125804af6284938380525bc4d7da0a953705fd1fb322c3b3db076c603), [transition-log.repo.test.ts](https://github.com/wopr-network/silo/pull/188/files#diff-e16ccd2ac93365993639f6d033417a176536c424ad7f3ed76c82cb5c7d58192b), and [sse.test.ts](https://github.com/wopr-network/silo/pull/188/files#diff-9b6750191682aa02fba5309ea1f83558c0dd66fdfa1f427697d8552d381161a0) now use `Date.now()`-relative values (e.g. 24h ago, 1–3h ago) or `new Date()` instead of fixed ISO strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5c1c2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by updating timestamp handling to use dynamic time values instead of fixed dates, reducing time-dependent test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->