### PR TITLE
test: fix weak assertions in nuke-dispatcher.test.ts (WOP-2170)

### DIFF
--- a/src/dispatcher/nuke-dispatcher.test.ts
+++ b/src/dispatcher/nuke-dispatcher.test.ts
@@ -18,7 +18,6 @@ describe("NukeDispatcher", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-    vi.restoreAllMocks();
   });
 
   /** Make execFile call its callback with an error — short-circuits launchContainer. */
@@ -60,7 +59,11 @@ describe("NukeDispatcher", () => {
       // Image is the last element of the docker run args
       expect(dockerArgs[dockerArgs.length - 1]).toBe("custom-image:latest");
     } finally {
-      process.env.NUKE_IMAGE = orig;
+      if (orig === undefined) {
+        delete process.env.NUKE_IMAGE;
+      } else {
+        process.env.NUKE_IMAGE = orig;
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
Closes WOP-2170

- Replace `expect(dispatcher).toBeDefined()` on lines 28 and 34 with behavioral assertions that verify the Docker image name is correctly resolved from `NUKE_IMAGE` env var and `opts.image` override
- Add `vi.mock("node:child_process")` to intercept `execFile` calls, capturing the docker run args without requiring real Docker
- Update the existing crash test to use the mock instead of real Docker (avoids real Docker dependency in CI)
- Add `afterEach` with `vi.clearAllMocks()` + `vi.restoreAllMocks()` to prevent mock state leaking between tests

## Test plan
- [ ] `npm run check` passes (biome + tsc)
- [ ] `npx vitest run src/dispatcher/nuke-dispatcher.test.ts` — all 5 tests pass

Generated with Claude Code

## Summary by Sourcery

Strengthen NukeDispatcher tests to assert Docker image resolution behavior while isolating them from real Docker execution.

Bug Fixes:
- Prevent NukeDispatcher tests from depending on a real Docker installation by mocking child_process.execFile.

Tests:
- Replace weak existence checks in NukeDispatcher tests with assertions that the resolved Docker image matches NUKE_IMAGE and opts.image values.
- Mock node:child_process execFile in NukeDispatcher tests and add a helper to simulate Docker launch failure.
- Add afterEach cleanup to clear and restore Vitest mocks in NukeDispatcher tests to avoid cross-test interference.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix weak assertions in nuke-dispatcher tests by mocking `execFile`
> Rewrites three tests in [nuke-dispatcher.test.ts](https://github.com/wopr-network/silo/pull/189/files#diff-6e8cfb8f9fb95dc0317a950583f4ace372853c9b42a985053c14651e3d88e986) to make stronger assertions by actually invoking `dispatcher.dispatch` rather than checking configuration in isolation.
>
> - Mocks `node:child_process` `execFile` via Vitest and adds a `rejectExecFile` helper that immediately fails the callback, simulating a docker launch failure without needing a real image.
> - Tests for `NUKE_IMAGE` env var and `opts.image` override now assert that `execFile` was called with `'docker'` and the correct image as the last argument.
> - The crash-result test now uses `rejectExecFile` instead of relying on a nonexistent image, making the failure deterministic.
> - Adds an `afterEach` hook to clear all mocks between tests.
>
> #### 🖇️ Linked Issues
> Addresses [WOP-2170](https://linear.app/wopr/issue/WOP-2170).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c871450.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->