### PR TITLE
fix: correct dist output paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,4 @@ EXPOSE 3001
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:${PORT}/health || exit 1
 
-CMD ["node", "dist/src/index.js"]
+CMD ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "main": "./dist/src/exports.js",
-  "types": "./dist/src/exports.d.ts",
+  "main": "./dist/exports.js",
+  "types": "./dist/exports.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/exports.d.ts",
-      "import": "./dist/src/exports.js"
+      "types": "./dist/exports.d.ts",
+      "import": "./dist/exports.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## Summary
- Fix Dockerfile CMD: `dist/src/index.js` → `dist/index.js`
- Fix package.json exports: `dist/src/exports` → `dist/exports`

tsc with only `src/**/*` in include auto-sets rootDir to `src/`, so output goes to `dist/` not `dist/src/`.

## Test plan
- [x] `pnpm check` passes
- [x] `pnpm build` produces `dist/index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dist output paths in Dockerfile and package.json
> Removes the `/src` segment from dist paths in two places: [Dockerfile](https://github.com/wopr-network/holyship/pull/195/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557) now runs `node dist/index.js`, and [package.json](https://github.com/wopr-network/holyship/pull/195/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) points `main`, `types`, and `exports` to `dist/exports.js` and `dist/exports.d.ts`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c0b85b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->