### PR TITLE
feat: restore runner gate files + runnerUrl + resolveRunnerUrl

### DIFF
--- a/src/engine/runner-adapter-registry.ts
+++ b/src/engine/runner-adapter-registry.ts
@@ -1,0 +1,99 @@
+/**
+ * Runner-backed AdapterRegistry — delegates all primitive gate ops to the
+ * holyshipper runner instead of resolving credentials and calling APIs locally.
+ *
+ * Drop-in replacement for AdapterRegistry. The gate evaluator calls
+ * registry.execute(integrationId, op, params, signal) — this implementation
+ * proxies to the runner's POST /gate endpoint. The cloud never touches
+ * provider APIs or credentials for gate evaluation.
+ */
+
+import { logger } from "../logger.js";
+
+/** Primitive op identifier, e.g. "vcs.ci_status". Matches integrations/types.ts when available. */
+type PrimitiveOp = string;
+/** Result from a primitive op. Matches integrations/types.ts when available. */
+type PrimitiveOpResult = Record<string, unknown>;
+
+export interface RunnerRegistryConfig {
+  /** Resolve the runner URL for an entity. Called with the integration ID. */
+  resolveRunnerUrl: (integrationId: string) => Promise<string | null>;
+  /** HTTP request timeout in ms. Default 30s. */
+  requestTimeoutMs?: number;
+}
+
+export class RunnerAdapterRegistry {
+  private readonly resolveRunnerUrl: RunnerRegistryConfig["resolveRunnerUrl"];
+  private readonly requestTimeoutMs: number;
+
+  constructor(config: RunnerRegistryConfig) {
+    this.resolveRunnerUrl = config.resolveRunnerUrl;
+    this.requestTimeoutMs = config.requestTimeoutMs ?? 30_000;
+  }
+
+  async execute(
+    integrationId: string,
+    op: PrimitiveOp,
+    params: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<PrimitiveOpResult> {
+    const runnerUrl = await this.resolveRunnerUrl(integrationId);
+    if (!runnerUrl) {
+      return { outcome: "error", message: "No runner available" };
+    }
+
+    const gateId = `gate-${integrationId}-${Date.now()}`;
+    const url = `${runnerUrl.replace(/\/$/, "")}/gate`;
+
+    logger.info(`[runner-registry] delegating ${op} to runner`, {
+      integrationId,
+      op,
+      runnerUrl,
+      gateId,
+    });
+
+    const controller = new AbortController();
+    // If caller provides a signal, forward abort (handle already-aborted case)
+    if (signal) {
+      if (signal.aborted) {
+        controller.abort();
+      } else {
+        signal.addEventListener("abort", () => controller.abort(), { once: true });
+      }
+    }
+    const timer = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          gateId,
+          entityId: integrationId,
+          op,
+          params,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        logger.error(`[runner-registry] runner error`, { op, status: res.status, body: text.slice(0, 200) });
+        return { outcome: "error", message: `Runner error: HTTP ${res.status}` };
+      }
+
+      const result = (await res.json()) as PrimitiveOpResult;
+      logger.info(`[runner-registry] result`, { op, outcome: result.outcome });
+      return result;
+    } catch (err) {
+      const isTimeout = err instanceof Error && err.name === "AbortError";
+      const message = isTimeout
+        ? `Runner gate timed out after ${this.requestTimeoutMs}ms`
+        : `Runner gate error: ${err instanceof Error ? err.message : String(err)}`;
+      logger.error(`[runner-registry] failed`, { op, error: message, isTimeout });
+      return { outcome: isTimeout ? "timeout" : "error", message };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/engine/runner-gate-client.ts
+++ b/src/engine/runner-gate-client.ts
@@ -1,0 +1,107 @@
+/**
+ * Runner Gate Client — delegates primitive gate evaluation to a holyshipper runner.
+ *
+ * Instead of evaluating gates locally (calling GitHub API directly), this handler
+ * sends the gate request to the runner's POST /gate endpoint. The runner evaluates
+ * locally and returns the outcome. The cloud never sees the underlying data.
+ *
+ * This is a drop-in replacement for the local PrimitiveOpHandler — the engine
+ * doesn't know or care whether gates are evaluated locally or on a runner.
+ */
+
+import { logger } from "../logger.js";
+import type { Entity } from "../repositories/interfaces.js";
+
+/** Handler signature matching the engine's PrimitiveOpHandler contract. */
+export type RunnerPrimitiveOpHandler = (
+  primitiveOp: string,
+  params: Record<string, unknown>,
+  entity: Entity,
+) => Promise<{ outcome: string; message?: string }>;
+
+export interface RunnerGateClientConfig {
+  /** Function to resolve the runner URL for a given entity. */
+  resolveRunnerUrl: (entity: Entity) => Promise<string | null>;
+  /** Timeout for the HTTP request to the runner, in ms. Default 30s. */
+  requestTimeoutMs?: number;
+}
+
+/**
+ * Create a PrimitiveOpHandler that delegates to a holyshipper runner.
+ * Returns the standard { outcome, message } shape expected by the gate evaluator.
+ */
+export function createRunnerGateHandler(config: RunnerGateClientConfig): RunnerPrimitiveOpHandler {
+  const requestTimeout = config.requestTimeoutMs ?? 30_000;
+
+  return async (primitiveOp: string, params: Record<string, unknown>, entity: Entity) => {
+    const runnerUrl = await config.resolveRunnerUrl(entity);
+    if (!runnerUrl) {
+      return { outcome: "error", message: "No runner available for entity" };
+    }
+
+    const gateId = `gate-${entity.id}-${Date.now()}`;
+    const body = JSON.stringify({
+      gateId,
+      entityId: entity.id,
+      op: primitiveOp,
+      params,
+    });
+
+    logger.info(`[runner-gate] delegating gate to runner`, {
+      entityId: entity.id,
+      op: primitiveOp,
+      runnerUrl,
+      gateId,
+    });
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), requestTimeout);
+
+    try {
+      const res = await fetch(`${runnerUrl.replace(/\/$/, "")}/gate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        logger.error(`[runner-gate] runner returned error`, {
+          entityId: entity.id,
+          op: primitiveOp,
+          status: res.status,
+          body: text.slice(0, 200),
+        });
+        return { outcome: "error", message: `Runner error: HTTP ${res.status}` };
+      }
+
+      const result = (await res.json()) as { outcome: string; message?: string; durationMs?: number };
+
+      logger.info(`[runner-gate] gate result received`, {
+        entityId: entity.id,
+        op: primitiveOp,
+        outcome: result.outcome,
+        durationMs: result.durationMs,
+      });
+
+      return { outcome: result.outcome, message: result.message };
+    } catch (err) {
+      const isTimeout = err instanceof Error && err.name === "AbortError";
+      const message = isTimeout
+        ? `Runner gate timed out after ${requestTimeout}ms`
+        : `Runner gate error: ${err instanceof Error ? err.message : String(err)}`;
+
+      logger.error(`[runner-gate] request failed`, {
+        entityId: entity.id,
+        op: primitiveOp,
+        error: message,
+        isTimeout,
+      });
+
+      return { outcome: isTimeout ? "timeout" : "error", message };
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+}

--- a/src/fleet/resolve-runner-url.ts
+++ b/src/fleet/resolve-runner-url.ts
@@ -1,0 +1,28 @@
+/**
+ * Resolve the runner URL for a given entity by querying the holyshipper_containers table.
+ * Returns the URL of the running container, or null if none is available.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { holyshipperContainers } from "../repositories/drizzle/schema.js";
+
+// biome-ignore lint/suspicious/noExplicitAny: cross-driver compat
+type Db = any;
+
+export function createResolveRunnerUrl(db: Db, tenantId: string) {
+  return async (entityId: string): Promise<string | null> => {
+    const rows = await db
+      .select({ runnerUrl: holyshipperContainers.runnerUrl })
+      .from(holyshipperContainers)
+      .where(
+        and(
+          eq(holyshipperContainers.entityId, entityId),
+          eq(holyshipperContainers.tenantId, tenantId),
+          eq(holyshipperContainers.status, "running"),
+        ),
+      )
+      .limit(1);
+
+    return rows[0]?.runnerUrl ?? null;
+  };
+}

--- a/src/repositories/drizzle/schema.ts
+++ b/src/repositories/drizzle/schema.ts
@@ -332,6 +332,7 @@ export const holyshipperContainers = pgTable(
       .notNull()
       .references(() => entities.id),
     containerId: text("container_id"),
+    runnerUrl: text("runner_url"),
     status: text("status").notNull().default("pending"),
     provisionedAt: timestamp("provisioned_at", { withTimezone: true }),
     tornDownAt: timestamp("torn_down_at", { withTimezone: true }),

--- a/tests/engine/runner-adapter-registry.test.ts
+++ b/tests/engine/runner-adapter-registry.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { RunnerAdapterRegistry } from "../../src/engine/runner-adapter-registry.js";
+
+const mockFetch = vi.fn();
+
+beforeAll(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("RunnerAdapterRegistry", () => {
+  it("delegates op to runner and returns result", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ outcome: "passed", message: "All checks passed", durationMs: 42 }),
+    });
+
+    const registry = new RunnerAdapterRegistry({
+      resolveRunnerUrl: async () => "http://runner:8080",
+    });
+
+    const result = await registry.execute("int-1", "vcs.ci_status", { ref: "abc123" });
+
+    expect(result.outcome).toBe("passed");
+    expect(result.message).toBe("All checks passed");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://runner:8080/gate",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("returns error when no runner available", async () => {
+    const registry = new RunnerAdapterRegistry({
+      resolveRunnerUrl: async () => null,
+    });
+
+    const result = await registry.execute("int-1", "vcs.ci_status", { ref: "abc" });
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("No runner available");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns error on HTTP failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "Internal Server Error",
+    });
+
+    const registry = new RunnerAdapterRegistry({
+      resolveRunnerUrl: async () => "http://runner:8080",
+    });
+
+    const result = await registry.execute("int-1", "vcs.ci_status", { ref: "abc" });
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("HTTP 500");
+  });
+
+  it("returns timeout on abort", async () => {
+    mockFetch.mockImplementationOnce(
+      (_url: string, opts: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts.signal.addEventListener("abort", () => {
+            const err = new Error("AbortError");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }),
+    );
+
+    const registry = new RunnerAdapterRegistry({
+      resolveRunnerUrl: async () => "http://runner:8080",
+      requestTimeoutMs: 50,
+    });
+
+    const result = await registry.execute("int-1", "vcs.ci_status", { ref: "abc" });
+
+    expect(result.outcome).toBe("timeout");
+  });
+
+  it("strips trailing slash from runner URL", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ outcome: "passed" }),
+    });
+
+    const registry = new RunnerAdapterRegistry({
+      resolveRunnerUrl: async () => "http://runner:8080/",
+    });
+
+    await registry.execute("int-1", "vcs.ci_status", { ref: "abc" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://runner:8080/gate",
+      expect.anything(),
+    );
+  });
+
+  it("forwards caller abort signal", async () => {
+    const callerController = new AbortController();
+    // Abort before calling execute — tests the already-aborted path
+    callerController.abort();
+
+    mockFetch.mockImplementationOnce((_url: string, opts: { signal: AbortSignal }) => {
+      // Signal should already be aborted
+      const err = new Error("AbortError");
+      err.name = "AbortError";
+      return Promise.reject(err);
+    });
+
+    const registry = new RunnerAdapterRegistry({
+      resolveRunnerUrl: async () => "http://runner:8080",
+      requestTimeoutMs: 60_000,
+    });
+
+    const result = await registry.execute("int-1", "vcs.ci_status", { ref: "abc" }, callerController.signal);
+    expect(result.outcome).toBe("timeout");
+  });
+});

--- a/tests/engine/runner-gate-client.test.ts
+++ b/tests/engine/runner-gate-client.test.ts
@@ -1,0 +1,130 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRunnerGateHandler } from "../../src/engine/runner-gate-client.js";
+import type { Entity } from "../../src/repositories/interfaces.js";
+
+const mockFetch = vi.fn();
+
+beforeAll(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+const entity: Entity = {
+  id: "entity-1",
+  flowId: "flow-1",
+  state: "coding",
+  refs: { repo: "org/repo" },
+  artifacts: {},
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  tenantId: "default",
+  failureCount: 0,
+  budgetCents: null,
+  spentCents: 0,
+  claimedBy: null,
+  claimedAt: null,
+};
+
+describe("createRunnerGateHandler", () => {
+  it("delegates to runner and returns outcome", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ outcome: "passed", message: "All checks passed", durationMs: 42 }),
+    });
+
+    const handler = createRunnerGateHandler({
+      resolveRunnerUrl: async () => "http://runner:8080",
+    });
+
+    const result = await handler("vcs.ci_status", { ref: "abc123" }, entity);
+
+    expect(result.outcome).toBe("passed");
+    expect(result.message).toBe("All checks passed");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://runner:8080/gate",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    // Verify the body contains the right fields
+    const call = mockFetch.mock.calls[0];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.entityId).toBe("entity-1");
+    expect(body.op).toBe("vcs.ci_status");
+    expect(body.params).toEqual({ ref: "abc123" });
+  });
+
+  it("returns error when no runner available", async () => {
+    const handler = createRunnerGateHandler({
+      resolveRunnerUrl: async () => null,
+    });
+
+    const result = await handler("vcs.ci_status", { ref: "abc" }, entity);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("No runner available");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns error on non-OK response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "Internal Server Error",
+    });
+
+    const handler = createRunnerGateHandler({
+      resolveRunnerUrl: async () => "http://runner:8080",
+    });
+
+    const result = await handler("vcs.ci_status", { ref: "abc" }, entity);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("HTTP 500");
+  });
+
+  it("returns timeout on abort", async () => {
+    mockFetch.mockImplementationOnce(
+      (_url: string, opts: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts.signal.addEventListener("abort", () => {
+            const err = new Error("AbortError");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }),
+    );
+
+    const handler = createRunnerGateHandler({
+      resolveRunnerUrl: async () => "http://runner:8080",
+      requestTimeoutMs: 50,
+    });
+
+    const result = await handler("vcs.ci_status", { ref: "abc" }, entity);
+
+    expect(result.outcome).toBe("timeout");
+    expect(result.message).toContain("timed out");
+  });
+
+  it("returns error on network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const handler = createRunnerGateHandler({
+      resolveRunnerUrl: async () => "http://runner:8080",
+    });
+
+    const result = await handler("vcs.ci_status", { ref: "abc" }, entity);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("ECONNREFUSED");
+  });
+});


### PR DESCRIPTION
## Summary

- Restore `runner-gate-client.ts` and `runner-adapter-registry.ts` accidentally deleted by #197
- Add `runner_url` column to `holyshipper_containers` table
- Add `createResolveRunnerUrl()` — queries container table for running runner URL by entity ID

## Context

These files are the cloud-side components of blind gate orchestration (companion to wopr-network/holyshipper#12). PR #197 accidentally deleted them during a squash merge.

Boot wiring (swapping `AdapterRegistry` for `RunnerAdapterRegistry`) will land when the platform branch merges primitive gate support to main.

## Test plan

- [x] 11 tests restored (runner-gate-client + runner-adapter-registry)
- [ ] Review bot feedback addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore runner-based gate orchestration components and wire them to resolve runner URLs from container records for delegating primitive gate evaluation to runners.

New Features:
- Add runner-backed gate client and adapter registry for delegating primitive gate operations to holyshipper runners.
- Introduce a helper to resolve runner URLs from the holyshipper_containers table based on entity and tenant context.
- Extend the holyshipper_containers schema with a runner_url field to track the URL of running containers.

Tests:
- Add and restore tests covering runner gate client behavior for success, error, timeout, and no-runner scenarios.
- Add and restore tests for the runner adapter registry including URL normalization, timeout handling, and abort signal propagation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore runner gate files with HTTP-based gate delegation and runner URL resolution
> - Adds [`RunnerAdapterRegistry`](https://github.com/wopr-network/holyship/pull/198/files#diff-35951b5bc57e22a9f2962a58c506bb7ea823e02813083298c092f003c16c5690) and [`createRunnerGateHandler`](https://github.com/wopr-network/holyship/pull/198/files#diff-da29ff879ad171ff6f3bb96a474ea872c1c42259f8c39d79ea9deb449e47a68f), both of which proxy primitive gate operations to a runner's `POST /gate` endpoint and return `{outcome, ...}` from the runner's JSON response.
> - Adds [`createResolveRunnerUrl`](https://github.com/wopr-network/holyship/pull/198/files#diff-13ef74398953d4d4e84a64127513b4d3956d6a652c1fa178a75263c6fb9620c2), which queries the `holyshipper_containers` table for a running container matching the entity and tenant, returning its `runner_url`.
> - Adds a `runner_url` text column to the [`holyshipperContainers`](https://github.com/wopr-network/holyship/pull/198/files#diff-3dca5edf2bb179874020fa4e311e0ba502bf63ab5f625cb1f593f34664152e1e) table schema.
> - Both gate handlers enforce a configurable timeout (default 30s) via `AbortController` and return `{outcome: 'timeout' | 'error', message}` on failure.
> - Risk: the new `runner_url` column requires a database migration before deployment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 161a475.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for delegating operations to external runners with HTTP integration.
  * Implemented timeout and error handling for remote operation execution with configurable timeouts (default 30 seconds).

* **Tests**
  * Added comprehensive test coverage for runner integration, including success, failure, timeout, and network error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->