### PR TITLE
feat: ephemeral holyshipper fleet lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "@scure/bip39": "^2.0.1",
     "@sentry/node": "^9.27.0",
     "@trpc/server": "^11.13.4",
-    "@wopr-network/platform-core": "^1.36.3",
+    "@wopr-network/platform-core": "^1.37.0",
+    "dockerode": "^4.0.9",
     "drizzle-orm": "^0.45.1",
     "handlebars": "^4.7.8",
     "hono": "^4.12.5",
@@ -59,6 +60,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
     "@electric-sql/pglite": "^0.3.16",
+    "@types/dockerode": "^4.0.1",
     "@types/node": "^25.3.3",
     "@types/pg": "^8.15.6",
     "@vitest/coverage-v8": "^4.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,11 @@ importers:
         specifier: ^11.13.4
         version: 11.13.4(typescript@5.9.3)
       '@wopr-network/platform-core':
-        specifier: ^1.36.3
-        version: 1.36.3(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)
+        specifier: ^1.37.0
+        version: 1.37.0(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)
+      dockerode:
+        specifier: ^4.0.9
+        version: 4.0.9
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8)
@@ -75,6 +78,9 @@ importers:
       '@electric-sql/pglite':
         specifier: ^0.3.16
         version: 0.3.16
+      '@types/dockerode':
+        specifier: ^4.0.1
+        version: 4.0.1
       '@types/node':
         specifier: ^25.3.3
         version: 25.3.5
@@ -1197,11 +1203,20 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@4.0.1':
+    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/mysql@2.15.26':
     resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@25.3.5':
     resolution: {integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==}
@@ -1217,6 +1232,9 @@ packages:
 
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -1268,8 +1286,8 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
-  '@wopr-network/platform-core@1.36.3':
-    resolution: {integrity: sha512-YgxaKO/EZHBNP0jt1cVuOXvmW8+HwPA/HICK0b8aQlL96/L+HkbZWeJzZeeiJ9XS8DTQuSyVzzw3Q+Cx7hKbFA==}
+  '@wopr-network/platform-core@1.37.0':
+    resolution: {integrity: sha512-RZoNThAK32qZaau6K8g/hajqaAezRzR8TQdIPmv/wZq/TU0tAQGt+JI92k+rnpgSc6VAEWMssX4LDPKY5Zc8Xw==}
     peerDependencies:
       '@trpc/server': '>=11'
       better-auth: '>=1.5'
@@ -2281,6 +2299,9 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -3313,11 +3334,26 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 25.3.5
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@4.0.1':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 25.3.5
+      '@types/ssh2': 1.15.5
+
   '@types/estree@1.0.8': {}
 
   '@types/mysql@2.15.26':
     dependencies:
       '@types/node': 25.3.5
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@25.3.5':
     dependencies:
@@ -3340,6 +3376,10 @@ snapshots:
       pg-types: 2.2.0
 
   '@types/shimmer@1.2.0': {}
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/tedious@4.0.14':
     dependencies:
@@ -3406,7 +3446,7 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@wopr-network/platform-core@1.36.3(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)':
+  '@wopr-network/platform-core@1.37.0(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)':
     dependencies:
       '@noble/hashes': 2.0.1
       '@scure/base': 2.0.0
@@ -4391,6 +4431,8 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
+
+  undici-types@5.26.5: {}
 
   undici-types@7.18.2: {}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,11 @@ const envSchema = z.object({
   // Fleet
   FLEET_DATA_DIR: z.string().default("/data/fleet"),
 
+  // Holyshipper ephemeral containers
+  HOLYSHIP_WORKER_IMAGE: optStr,
+  HOLYSHIP_GATEWAY_KEY: optStr,
+  DOCKER_NETWORK: optStr,
+
   // Notifications (Resend)
   RESEND_API_KEY: optStr,
   FROM_EMAIL: z.string().default("noreply@holyship.wtf"),

--- a/src/fleet/entity-lifecycle.ts
+++ b/src/fleet/entity-lifecycle.ts
@@ -1,20 +1,33 @@
 import { and, eq } from "drizzle-orm";
 import type { EngineEvent, IEventBusAdapter } from "../engine/event-types.js";
+import { logger } from "../logger.js";
 import { holyshipperContainers } from "../repositories/drizzle/schema.js";
-import type { IFleetManager } from "./provision-holyshipper.js";
+import type { IEntityRepository } from "../repositories/interfaces.js";
+import type { IFleetManager, ProvisionConfig } from "./provision-holyshipper.js";
 
 // biome-ignore lint/suspicious/noExplicitAny: cross-driver compat
 type Db = any;
 
 /**
- * Manages the lifecycle of holyshipper containers in response to engine events.
- * Uses the `holyshipper_containers` DB table (not in-memory Map) for persistence.
+ * Manages the lifecycle of ephemeral holyshipper containers.
+ *
+ * Each invocation gets its own container. The container lives for:
+ *   prompt execution + gate evaluation
+ * Then tears down on state transition (success or failure).
+ *
+ * Flow: invocation.created → provision → credentials → checkout → dispatch
+ *       → signal → gate (via POST /gate to same container) → transition → teardown
+ *
+ * Gate failure triggers a transition (possibly back to same state with failure context),
+ * which tears down the container. The next invocation provisions a fresh one.
  */
 export class EntityLifecycleManager implements IEventBusAdapter {
   constructor(
     private db: Db,
     private tenantId: string,
     private fleetManager: IFleetManager,
+    private entityRepo: IEntityRepository,
+    private getGithubToken: () => Promise<string | null>,
   ) {}
 
   async emit(event: EngineEvent): Promise<void> {
@@ -22,18 +35,20 @@ export class EntityLifecycleManager implements IEventBusAdapter {
       case "invocation.created":
         await this.onInvocationCreated(event);
         break;
-      case "gate.failed":
-      case "gate.timedOut":
-        await this.onGateFailure(event);
-        break;
       case "entity.transitioned":
-        await this.onTransition(event);
+        // Teardown on EVERY transition — not just terminal.
+        // The next state's invocation.created will provision a fresh container.
+        await this.teardownForEntity(event.entityId);
         break;
     }
   }
 
   private async onInvocationCreated(event: EngineEvent & { type: "invocation.created" }): Promise<void> {
     const entityId = event.entityId;
+
+    // Skip passive invocations — they don't need a container
+    if ("mode" in event && event.mode === "passive") return;
+
     // Check if a container already exists for this entity
     const existing = await this.db
       .select()
@@ -46,6 +61,34 @@ export class EntityLifecycleManager implements IEventBusAdapter {
         ),
       );
     if (existing.length > 0) return;
+
+    // Build provision config from entity artifacts/refs
+    const entity = await this.entityRepo.get(entityId);
+    if (!entity) {
+      logger.error("[lifecycle] entity not found for provisioning", { entityId });
+      return;
+    }
+
+    const repoFullName = (entity.artifacts?.repoFullName as string) ?? "";
+    const [owner = "", repo = ""] = repoFullName.includes("/") ? repoFullName.split("/") : ["", ""];
+    const issueNumber = Number(entity.artifacts?.issueNumber) || 0;
+    const flowName = entity.flowId ?? "";
+
+    let githubToken = "";
+    try {
+      githubToken = (await this.getGithubToken()) ?? "";
+    } catch (err) {
+      logger.warn("[lifecycle] failed to get GitHub token", { error: String(err) });
+    }
+
+    const provisionConfig: ProvisionConfig = {
+      entityId,
+      flowName,
+      owner,
+      repo,
+      issueNumber,
+      githubToken,
+    };
 
     // Create a pending record
     const id = crypto.randomUUID();
@@ -60,14 +103,16 @@ export class EntityLifecycleManager implements IEventBusAdapter {
 
     // Provision the container
     try {
-      const containerId = await this.fleetManager.provision(entityId, {
+      const containerId = await this.fleetManager.provision(entityId, provisionConfig);
+
+      logger.info("[lifecycle] container provisioned", {
         entityId,
-        flowName: "",
-        owner: "",
-        repo: "",
-        issueNumber: 0,
-        githubToken: "",
+        containerId,
+        owner,
+        repo,
+        issueNumber,
       });
+
       await this.db
         .update(holyshipperContainers)
         .set({
@@ -77,23 +122,15 @@ export class EntityLifecycleManager implements IEventBusAdapter {
           updatedAt: new Date(),
         })
         .where(eq(holyshipperContainers.id, id));
-    } catch {
+    } catch (err) {
+      logger.error("[lifecycle] container provision failed", {
+        entityId,
+        error: err instanceof Error ? err.message : String(err),
+      });
       await this.db
         .update(holyshipperContainers)
         .set({ status: "failed", updatedAt: new Date() })
         .where(eq(holyshipperContainers.id, id));
-    }
-  }
-
-  private async onGateFailure(event: EngineEvent & { type: "gate.failed" | "gate.timedOut" }): Promise<void> {
-    await this.teardownForEntity(event.entityId);
-  }
-
-  private async onTransition(event: EngineEvent & { type: "entity.transitioned" }): Promise<void> {
-    // Check if the new state is terminal (done, failed, cancelled, budget_exceeded)
-    const terminalStates = ["done", "failed", "cancelled", "budget_exceeded"];
-    if ("toState" in event && terminalStates.includes(event.toState as string)) {
-      await this.teardownForEntity(event.entityId);
     }
   }
 
@@ -113,8 +150,16 @@ export class EntityLifecycleManager implements IEventBusAdapter {
       if (container.containerId) {
         try {
           await this.fleetManager.teardown(container.containerId);
-        } catch {
-          // Best effort teardown
+          logger.info("[lifecycle] container torn down", {
+            entityId,
+            containerId: container.containerId,
+          });
+        } catch (err) {
+          logger.warn("[lifecycle] container teardown failed (best effort)", {
+            entityId,
+            containerId: container.containerId,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
       }
       await this.db

--- a/src/fleet/holyshipper-fleet-manager.ts
+++ b/src/fleet/holyshipper-fleet-manager.ts
@@ -1,0 +1,216 @@
+/**
+ * HolyshipperFleetManager — wraps platform-core FleetManager for ephemeral containers.
+ *
+ * Each invocation gets a fresh container:
+ *   1. FleetManager.create() — pull image, create + start container
+ *   2. POST /credentials — inject gateway key + GitHub token
+ *   3. POST /checkout — clone repo(s)
+ *   4. Container is now ready for dispatch + gate evaluation
+ *   5. FleetManager.remove() — stop + delete container on teardown
+ *
+ * Containers use restartPolicy "no" — they don't restart when the process exits.
+ * The container stays alive between dispatch and gate evaluation (the worker-runtime
+ * HTTP server keeps running), then is torn down on state transition.
+ */
+
+import type { FleetManager } from "@wopr-network/platform-core/fleet";
+import { logger } from "../logger.js";
+import type { IFleetManager, ProvisionConfig } from "./provision-holyshipper.js";
+
+export interface HolyshipperFleetManagerConfig {
+  /** Platform-core FleetManager instance (wraps Docker). */
+  fleetManager: FleetManager;
+  /** GHCR image for holyshipper workers. */
+  image: string;
+  /** Gateway URL for inference (e.g., "http://api:3001/v1"). */
+  gatewayUrl: string;
+  /** Gateway service key for authentication. */
+  gatewayKey: string;
+  /** Docker network to attach containers to (for /v1 access). */
+  network?: string;
+  /** Port the worker-runtime listens on inside the container. */
+  containerPort?: number;
+}
+
+export class HolyshipperFleetManager implements IFleetManager {
+  private readonly fleet: FleetManager;
+  private readonly image: string;
+  private readonly gatewayUrl: string;
+  private readonly gatewayKey: string;
+  private readonly network: string | undefined;
+  private readonly containerPort: number;
+  /** Track host ports for runner URL resolution. */
+  private readonly runnerUrls = new Map<string, string>();
+
+  constructor(config: HolyshipperFleetManagerConfig) {
+    this.fleet = config.fleetManager;
+    this.image = config.image;
+    this.gatewayUrl = config.gatewayUrl;
+    this.gatewayKey = config.gatewayKey;
+    this.network = config.network;
+    this.containerPort = config.containerPort ?? 8080;
+  }
+
+  async provision(entityId: string, config: ProvisionConfig): Promise<string> {
+    const botId = `hs-${entityId.slice(0, 8)}-${Date.now()}`;
+
+    logger.info("[fleet] provisioning holyshipper container", {
+      botId,
+      entityId,
+      image: this.image,
+      owner: config.owner,
+      repo: config.repo,
+    });
+
+    // Build env vars for the container
+    const env: Record<string, string> = {
+      HOLYSHIP_GATEWAY_KEY: this.gatewayKey,
+      HOLYSHIP_GATEWAY_URL: this.gatewayUrl,
+      HOLYSHIP_ENTITY_ID: entityId,
+      PORT: String(this.containerPort),
+    };
+
+    if (config.githubToken) {
+      env.GH_TOKEN = config.githubToken;
+      env.GITHUB_TOKEN = config.githubToken;
+    }
+
+    // Create ephemeral container via platform-core FleetManager
+    const profile = await this.fleet.create({
+      id: botId,
+      name: botId,
+      tenantId: "holyship",
+      image: this.image,
+      env,
+      restartPolicy: "no",
+      description: `Ephemeral worker for entity ${entityId}`,
+      updatePolicy: "manual",
+      releaseChannel: "stable",
+    });
+
+    const containerId = profile.id;
+
+    // Wait for container to be ready (health check)
+    const runnerUrl = await this.waitForReady(containerId, botId);
+
+    // Inject credentials
+    await this.postCredentials(runnerUrl, config);
+
+    // Checkout repo(s)
+    if (config.owner && config.repo) {
+      await this.postCheckout(runnerUrl, config);
+    }
+
+    // Store runner URL for gate delegation
+    this.runnerUrls.set(entityId, runnerUrl);
+
+    logger.info("[fleet] holyshipper container ready", {
+      botId,
+      entityId,
+      runnerUrl,
+    });
+
+    return containerId;
+  }
+
+  async teardown(containerId: string): Promise<void> {
+    logger.info("[fleet] tearing down holyshipper container", { containerId });
+
+    // Remove runner URL mapping
+    for (const [entityId, url] of this.runnerUrls) {
+      if (url.includes(containerId) || entityId === containerId) {
+        this.runnerUrls.delete(entityId);
+      }
+    }
+
+    try {
+      await this.fleet.remove(containerId);
+    } catch (err) {
+      logger.warn("[fleet] container removal failed (may already be gone)", {
+        containerId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** Get the runner URL for an entity (for gate delegation). */
+  getRunnerUrl(entityId: string): string | null {
+    return this.runnerUrls.get(entityId) ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private async waitForReady(_containerId: string, botId: string, timeoutMs = 30_000): Promise<string> {
+    const start = Date.now();
+    const interval = 1000;
+
+    // For now, construct URL from container name + network
+    // In production this would inspect the container for the mapped port
+    const runnerUrl = this.network ? `http://${botId}:${this.containerPort}` : `http://localhost:${this.containerPort}`;
+
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const res = await fetch(`${runnerUrl}/health`, {
+          signal: AbortSignal.timeout(2000),
+        });
+        if (res.ok) return runnerUrl;
+      } catch {
+        // Not ready yet
+      }
+      await new Promise((r) => setTimeout(r, interval));
+    }
+
+    throw new Error(`Container ${botId} did not become ready within ${timeoutMs}ms`);
+  }
+
+  private async postCredentials(runnerUrl: string, config: ProvisionConfig): Promise<void> {
+    const body: Record<string, unknown> = {
+      gateway: { key: this.gatewayKey },
+      gatewayUrl: this.gatewayUrl,
+    };
+    if (config.githubToken) {
+      body.github = { token: config.githubToken };
+    }
+
+    const res = await fetch(`${runnerUrl}/credentials`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Credential injection failed: HTTP ${res.status} — ${text}`);
+    }
+
+    logger.info("[fleet] credentials injected", { entityId: config.entityId });
+  }
+
+  private async postCheckout(runnerUrl: string, config: ProvisionConfig): Promise<void> {
+    const repoFullName = config.owner && config.repo ? `${config.owner}/${config.repo}` : undefined;
+    if (!repoFullName) return;
+
+    const res = await fetch(`${runnerUrl}/checkout`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        repo: repoFullName,
+        entityId: config.entityId,
+      }),
+      signal: AbortSignal.timeout(120_000), // Cloning can take a while
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Checkout failed: HTTP ${res.status} — ${text}`);
+    }
+
+    logger.info("[fleet] repo checked out", {
+      entityId: config.entityId,
+      repo: repoFullName,
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,6 +359,54 @@ async function main() {
   // Start reaper
   const stopReaper = engine.startReaper(30_000);
 
+  // ─── 9b. Holyshipper fleet lifecycle (ephemeral containers) ────────
+  if (config.HOLYSHIP_WORKER_IMAGE && config.HOLYSHIP_GATEWAY_KEY) {
+    try {
+      const Docker = (await import("dockerode")).default;
+      const docker = new Docker();
+      const { ProfileStore } = await import("@wopr-network/platform-core/fleet/profile-store");
+      const { FleetManager } = await import("@wopr-network/platform-core/fleet");
+
+      const profileStore = new ProfileStore(`${config.FLEET_DATA_DIR}/profiles`);
+      const coreFleetManager = new FleetManager(docker, profileStore);
+
+      const { HolyshipperFleetManager } = await import("./fleet/holyshipper-fleet-manager.js");
+      const holyshipperFleet = new HolyshipperFleetManager({
+        fleetManager: coreFleetManager,
+        image: config.HOLYSHIP_WORKER_IMAGE,
+        gatewayUrl: config.APP_BASE_URL ? `${config.APP_BASE_URL}/v1` : "http://localhost:3001/v1",
+        gatewayKey: config.HOLYSHIP_GATEWAY_KEY,
+        network: config.DOCKER_NETWORK,
+      });
+
+      const { EntityLifecycleManager } = await import("./fleet/entity-lifecycle.js");
+      const lifecycleManager = new EntityLifecycleManager(
+        engineDb,
+        tenantId,
+        holyshipperFleet,
+        repos.entities,
+        async () => {
+          if (!hasGitHubApp) return null;
+          const installations = await installationRepo.listByTenant(tenantId);
+          if (installations.length === 0) return null;
+          const { token } = await getInstallationAccessToken(
+            config.GITHUB_APP_ID as string,
+            config.GITHUB_APP_PRIVATE_KEY as string,
+            installations[0].installationId,
+          );
+          return token;
+        },
+      );
+
+      eventEmitter.register(lifecycleManager);
+      logger.info("Holyshipper fleet lifecycle registered (ephemeral containers)");
+    } catch (err) {
+      logger.warn("Holyshipper fleet lifecycle setup failed (non-fatal)", (err as Error).message);
+    }
+  } else {
+    logger.info("Holyshipper fleet lifecycle disabled (HOLYSHIP_WORKER_IMAGE or HOLYSHIP_GATEWAY_KEY not set)");
+  }
+
   // ─── 10. Engine REST routes (claim/report for holyshippers) ────────
   app.route(
     "/api",


### PR DESCRIPTION
## Summary
- Wire `EntityLifecycleManager` as event adapter — listens to `invocation.created` and `entity.transitioned`
- `HolyshipperFleetManager` wraps platform-core `FleetManager` for ephemeral container provisioning
- Each invocation gets a fresh container: provision → credentials → checkout → dispatch → gate → teardown
- Teardown on **every** transition (not just terminal) — next state provisions a new container
- Container stays alive between dispatch completion and gate evaluation (runner-gate-client finds it via `holyshipper_containers` table)
- Bump `@wopr-network/platform-core` to 1.37.0 (FleetManager export)

## Config
New env vars (all optional, lifecycle disabled if not set):
- `HOLYSHIP_WORKER_IMAGE` — GHCR image for holyshipper workers
- `HOLYSHIP_GATEWAY_KEY` — gateway service key for container auth
- `DOCKER_NETWORK` — Docker network for container-to-API connectivity

## Test plan
- [ ] `npm run check` passes (biome + tsc)
- [ ] `npm run build` succeeds
- [ ] Without HOLYSHIP_WORKER_IMAGE set, lifecycle logs "disabled" and boot proceeds
- [ ] With image set, entity creation triggers container provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an ephemeral holyshipper container lifecycle wired to engine events for per-invocation worker provisioning and teardown.

New Features:
- Add HolyshipperFleetManager wrapper around platform-core FleetManager to provision, configure, and teardown ephemeral worker containers per invocation.
- Enable EntityLifecycleManager to provision containers based on entity metadata and GitHub credentials on invocation creation and teardown containers on every entity transition.
- Wire holyshipper fleet lifecycle into application startup, conditionally enabling it via new configuration and GitHub token lookup logic.

Enhancements:
- Extend EntityLifecycleManager with entity repository and GitHub token integration to build richer provisioning configs and improve observability with structured logging.

Build:
- Add dockerode and its TypeScript types as dependencies and bump @wopr-network/platform-core to 1.37.0 to use the exported FleetManager.

Documentation:
- Document new holyshipper ephemeral container configuration environment variables in the config schema.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ephemeral holyshipper fleet lifecycle for per-invocation container provisioning
> - Adds `HolyshipperFleetManager` in [src/fleet/holyshipper-fleet-manager.ts](https://github.com/wopr-network/holyship/pull/202/files#diff-443adb71a30642a483836e56957260945f1bfdd062a456fd671df5c7f4ce643d) that provisions ephemeral containers via `dockerode` and `platform-core` FleetManager, injects credentials, optionally triggers repo checkout, and tears down containers on completion.
> - Updates `EntityLifecycleManager` in [src/fleet/entity-lifecycle.ts](https://github.com/wopr-network/holyship/pull/202/files#diff-3f3b968cecedc77c101a1eff1a9d3241dda53bc147f5bd3f1e1e45a23298fa8e) to provision a container on `invocation.created` (non-passive) using entity repo/issue/flow context and a GitHub installation token, and tear down on any `entity.transitioned` event.
> - Wires the lifecycle manager in [src/index.ts](https://github.com/wopr-network/holyship/pull/202/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) at startup when `HOLYSHIP_WORKER_IMAGE` and `HOLYSHIP_GATEWAY_KEY` env vars are set; setup failure is non-fatal.
> - Adds three new optional env vars (`HOLYSHIP_WORKER_IMAGE`, `HOLYSHIP_GATEWAY_KEY`, `DOCKER_NETWORK`) to [src/config.ts](https://github.com/wopr-network/holyship/pull/202/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012).
> - Behavioral Change: `gate.failed` and `gate.timedOut` events no longer trigger teardown; teardown now fires on every `entity.transitioned` event.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5b13eec. 4 files reviewed, 7 issues evaluated, 2 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/fleet/entity-lifecycle.ts — 0 comments posted, 3 evaluated, 2 filtered</summary>
>
> - [line 53](https://github.com/wopr-network/holyship/blob/5b13eecd5da3b0d6ed361643b2f1ed94ad8f9904/src/fleet/entity-lifecycle.ts#L53): Race condition in `onInvocationCreated`: The check for existing container (lines 53-63) and the insert of a new pending record (lines 95-102) are not atomic. If two `invocation.created` events arrive concurrently for the same `entityId`, both will pass the existence check (finding no running container), both will insert pending records with different UUIDs, and both will attempt to provision containers. This leads to duplicate containers being provisioned for the same entity, wasting resources and potentially causing inconsistent state. <b>[ Out of scope ]</b>
> - [line 60](https://github.com/wopr-network/holyship/blob/5b13eecd5da3b0d6ed361643b2f1ed94ad8f9904/src/fleet/entity-lifecycle.ts#L60): Race condition: The check at lines 53-62 queries for containers with `status: "running"`, but the insert at line 99 creates a record with `status: "pending"`. If two `invocation.created` events fire concurrently for the same entity, both will pass the existence check (neither sees a "running" container), both will insert "pending" records, and both will provision separate containers. The check should also include `status: "pending"` or use an atomic upsert/lock to prevent duplicate container provisioning. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->