### PR TITLE
fix: persist runner URL to DB, not in-memory Map

### DIFF
--- a/src/fleet/entity-lifecycle.ts
+++ b/src/fleet/entity-lifecycle.ts
@@ -103,11 +103,12 @@ export class EntityLifecycleManager implements IEventBusAdapter {
 
     // Provision the container
     try {
-      const containerId = await this.fleetManager.provision(entityId, provisionConfig);
+      const { containerId, runnerUrl } = await this.fleetManager.provision(entityId, provisionConfig);
 
       logger.info("[lifecycle] container provisioned", {
         entityId,
         containerId,
+        runnerUrl,
         owner,
         repo,
         issueNumber,
@@ -117,6 +118,7 @@ export class EntityLifecycleManager implements IEventBusAdapter {
         .update(holyshipperContainers)
         .set({
           containerId,
+          runnerUrl,
           status: "running",
           provisionedAt: new Date(),
           updatedAt: new Date(),

--- a/src/fleet/holyshipper-fleet-manager.ts
+++ b/src/fleet/holyshipper-fleet-manager.ts
@@ -15,7 +15,7 @@
 
 import type { FleetManager } from "@wopr-network/platform-core/fleet";
 import { logger } from "../logger.js";
-import type { IFleetManager, ProvisionConfig } from "./provision-holyshipper.js";
+import type { IFleetManager, ProvisionConfig, ProvisionResult } from "./provision-holyshipper.js";
 
 export interface HolyshipperFleetManagerConfig {
   /** Platform-core FleetManager instance (wraps Docker). */
@@ -39,8 +39,6 @@ export class HolyshipperFleetManager implements IFleetManager {
   private readonly gatewayKey: string;
   private readonly network: string | undefined;
   private readonly containerPort: number;
-  /** Track host ports for runner URL resolution. */
-  private readonly runnerUrls = new Map<string, string>();
 
   constructor(config: HolyshipperFleetManagerConfig) {
     this.fleet = config.fleetManager;
@@ -51,7 +49,7 @@ export class HolyshipperFleetManager implements IFleetManager {
     this.containerPort = config.containerPort ?? 8080;
   }
 
-  async provision(entityId: string, config: ProvisionConfig): Promise<string> {
+  async provision(entityId: string, config: ProvisionConfig): Promise<ProvisionResult> {
     const botId = `hs-${entityId.slice(0, 8)}-${Date.now()}`;
 
     logger.info("[fleet] provisioning holyshipper container", {
@@ -101,27 +99,17 @@ export class HolyshipperFleetManager implements IFleetManager {
       await this.postCheckout(runnerUrl, config);
     }
 
-    // Store runner URL for gate delegation
-    this.runnerUrls.set(entityId, runnerUrl);
-
     logger.info("[fleet] holyshipper container ready", {
       botId,
       entityId,
       runnerUrl,
     });
 
-    return containerId;
+    return { containerId, runnerUrl };
   }
 
   async teardown(containerId: string): Promise<void> {
     logger.info("[fleet] tearing down holyshipper container", { containerId });
-
-    // Remove runner URL mapping
-    for (const [entityId, url] of this.runnerUrls) {
-      if (url.includes(containerId) || entityId === containerId) {
-        this.runnerUrls.delete(entityId);
-      }
-    }
 
     try {
       await this.fleet.remove(containerId);
@@ -131,11 +119,6 @@ export class HolyshipperFleetManager implements IFleetManager {
         error: err instanceof Error ? err.message : String(err),
       });
     }
-  }
-
-  /** Get the runner URL for an entity (for gate delegation). */
-  getRunnerUrl(entityId: string): string | null {
-    return this.runnerUrls.get(entityId) ?? null;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/fleet/provision-holyshipper.ts
+++ b/src/fleet/provision-holyshipper.ts
@@ -2,8 +2,13 @@
  * Fleet management: provision and teardown holyshipper containers.
  */
 
+export interface ProvisionResult {
+  containerId: string;
+  runnerUrl: string;
+}
+
 export interface IFleetManager {
-  provision(entityId: string, config: ProvisionConfig): Promise<string>;
+  provision(entityId: string, config: ProvisionConfig): Promise<ProvisionResult>;
   teardown(containerId: string): Promise<void>;
 }
 
@@ -23,9 +28,12 @@ export interface ProvisionConfig {
 
 /**
  * Provision a holyshipper container for the given entity.
- * Returns the container ID.
+ * Returns the container ID and runner URL.
  */
-export async function provisionHolyshipper(fleetManager: IFleetManager, config: ProvisionConfig): Promise<string> {
+export async function provisionHolyshipper(
+  fleetManager: IFleetManager,
+  config: ProvisionConfig,
+): Promise<ProvisionResult> {
   return fleetManager.provision(config.entityId, config);
 }
 


### PR DESCRIPTION
## Summary
- `IFleetManager.provision()` now returns `{ containerId, runnerUrl }` instead of just `containerId`
- `EntityLifecycleManager` writes `runnerUrl` to `holyshipper_containers` table on provision
- Killed the in-memory `Map<entityId, runnerUrl>` from `HolyshipperFleetManager`
- `runner-gate-client` already resolves URLs from DB via `resolve-runner-url.ts` — this was the missing write side

## Why
Runner URL was stored in a `Map` — lost on process restart. Gate delegation would fail for any container provisioned before the restart. DB is the source of truth.

## Test plan
- [ ] `npm run check` passes
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Persist holyshipper runner URLs in the database and adjust fleet provisioning interfaces to return both container ID and runner URL.

New Features:
- Return both containerId and runnerUrl from the holyshipper fleet provisioning API.

Enhancements:
- Remove in-memory tracking of runner URLs from HolyshipperFleetManager in favor of database persistence.
- Update entity lifecycle management to store runner URLs in the holyshipper_containers table when provisioning.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist runner URL to the database instead of an in-memory map
> - `HolyshipperFleetManager.provision` now returns a `ProvisionResult` object containing both `containerId` and `runnerUrl` instead of just a string `containerId`.
> - The `runnerUrls` map and `getRunnerUrl` method are removed from `HolyshipperFleetManager`; the runner URL is no longer held in memory.
> - `EntityLifecycleManager.onInvocationCreated` persists `runnerUrl` directly to the `holyshipper_containers` DB record and includes it in log context.
> - Risk: `getRunnerUrl` is no longer available at runtime; any callers outside this PR must read `runnerUrl` from the DB or from the `provision` return value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ea11e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced fleet provisioning to return both container and runner URL information instead of container ID alone.
  * Runner URL is now persisted in the database alongside provisioning metadata.
  * Streamlined provisioning data structure for more complete resource information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->