### PR TITLE
feat: reactive worker pool for invocation execution

### DIFF
--- a/src/fleet/worker-pool.ts
+++ b/src/fleet/worker-pool.ts
@@ -1,0 +1,237 @@
+/**
+ * Reactive Worker Pool — event-driven execution of invocations.
+ *
+ * Subscribes to engine events as an IEventBusAdapter. When invocation.created
+ * fires, a worker claims it and runs the full lifecycle:
+ *   provision container → dispatch prompt → collect signal → processSignal → teardown
+ *
+ * Concurrency is bounded by pool size. If all workers are busy, events queue.
+ * No polling. No sleep loops. Purely reactive.
+ */
+
+import { eq } from "drizzle-orm";
+import type { Engine } from "../engine/engine.js";
+import type { EngineEvent, IEventBusAdapter } from "../engine/event-types.js";
+import { logger } from "../logger.js";
+import { holyshipperContainers } from "../repositories/drizzle/schema.js";
+import type { IInvocationRepository } from "../repositories/interfaces.js";
+import type { IFleetManager, ProvisionConfig } from "./provision-holyshipper.js";
+
+// biome-ignore lint/suspicious/noExplicitAny: cross-driver compat
+type Db = any;
+
+const AGENT_ROLE_TO_TIER: Record<string, string> = {
+  "wopr-architect": "sonnet",
+  "wopr-coder": "sonnet",
+  "wopr-reviewer": "haiku",
+  "wopr-technical-writer": "haiku",
+};
+
+export interface WorkerPoolConfig {
+  engine: Engine;
+  db: Db;
+  tenantId: string;
+  fleetManager: IFleetManager;
+  invocationRepo: IInvocationRepository;
+  getGithubToken: () => Promise<string | null>;
+  /** Max concurrent workers (containers). Default 4. */
+  poolSize?: number;
+}
+
+export class WorkerPool implements IEventBusAdapter {
+  private readonly engine: Engine;
+  private readonly db: Db;
+  private readonly tenantId: string;
+  private readonly fleetManager: IFleetManager;
+  private readonly invocationRepo: IInvocationRepository;
+  private readonly getGithubToken: () => Promise<string | null>;
+  private readonly poolSize: number;
+
+  private activeWorkers = 0;
+  private readonly pending: Array<EngineEvent & { type: "invocation.created" }> = [];
+
+  constructor(config: WorkerPoolConfig) {
+    this.engine = config.engine;
+    this.db = config.db;
+    this.tenantId = config.tenantId;
+    this.fleetManager = config.fleetManager;
+    this.invocationRepo = config.invocationRepo;
+    this.getGithubToken = config.getGithubToken;
+    this.poolSize = config.poolSize ?? 4;
+  }
+
+  async emit(event: EngineEvent): Promise<void> {
+    if (event.type !== "invocation.created") return;
+    if ("mode" in event && event.mode === "passive") return;
+
+    if (this.activeWorkers < this.poolSize) {
+      void this.runWorker(event);
+    } else {
+      this.pending.push(event);
+      logger.info("[worker-pool] queued (all slots busy)", {
+        entityId: event.entityId,
+        queueDepth: this.pending.length,
+        activeWorkers: this.activeWorkers,
+      });
+    }
+  }
+
+  private async runWorker(event: EngineEvent & { type: "invocation.created" }): Promise<void> {
+    this.activeWorkers++;
+    const workerId = this.activeWorkers;
+
+    try {
+      await this.executeInvocation(workerId, event);
+    } catch (err) {
+      logger.error(`[worker-${workerId}] unhandled error`, {
+        entityId: event.entityId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.activeWorkers--;
+      const next = this.pending.shift();
+      if (next) void this.runWorker(next);
+    }
+  }
+
+  private async executeInvocation(
+    workerId: number,
+    event: EngineEvent & { type: "invocation.created" },
+  ): Promise<void> {
+    const { entityId, invocationId, stage } = event;
+    const tag = `[worker-${workerId}]`;
+
+    // 1. Read invocation for prompt
+    const invocation = await this.invocationRepo.get(invocationId);
+    if (!invocation?.prompt) {
+      logger.error(`${tag} invocation missing or no prompt`, { invocationId });
+      return;
+    }
+
+    const { prompt } = invocation;
+    const artifacts = invocation.artifacts ?? {};
+    const repoFullName = (artifacts.repoFullName as string) ?? "";
+    const [owner = "", repo = ""] = repoFullName.includes("/") ? repoFullName.split("/") : ["", ""];
+    const issueNumber = Number(artifacts.issueNumber) || 0;
+    const agentRole = invocation.agentRole;
+
+    let githubToken = "";
+    try {
+      githubToken = (await this.getGithubToken()) ?? "";
+    } catch (err) {
+      logger.warn(`${tag} github token failed`, { error: String(err) });
+    }
+
+    const provisionConfig: ProvisionConfig = { entityId, flowName: stage, owner, repo, issueNumber, githubToken };
+
+    // 2. Provision container
+    logger.info(`${tag} provisioning`, { entityId, stage, owner, repo });
+
+    const dbRecordId = crypto.randomUUID();
+    await this.db.insert(holyshipperContainers).values({
+      id: dbRecordId,
+      tenantId: this.tenantId,
+      entityId,
+      status: "pending",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    let runnerUrl: string;
+    let containerId: string;
+    try {
+      const result = await this.fleetManager.provision(entityId, provisionConfig);
+      runnerUrl = result.runnerUrl;
+      containerId = result.containerId;
+
+      await this.db
+        .update(holyshipperContainers)
+        .set({ containerId, runnerUrl, status: "running", provisionedAt: new Date(), updatedAt: new Date() })
+        .where(eq(holyshipperContainers.id, dbRecordId));
+    } catch (err) {
+      logger.error(`${tag} provision failed`, { entityId, error: err instanceof Error ? err.message : String(err) });
+      await this.db
+        .update(holyshipperContainers)
+        .set({ status: "failed", updatedAt: new Date() })
+        .where(eq(holyshipperContainers.id, dbRecordId));
+      return;
+    }
+
+    // 3. Dispatch prompt
+    const modelTier = AGENT_ROLE_TO_TIER[agentRole ?? ""] ?? "sonnet";
+    logger.info(`${tag} dispatching`, { entityId, invocationId, modelTier, promptLength: prompt.length });
+
+    try {
+      const res = await fetch(`${runnerUrl.replace(/\/$/, "")}/dispatch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt, modelTier }),
+        signal: AbortSignal.timeout(600_000),
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        logger.error(`${tag} dispatch HTTP error`, { entityId, status: res.status, body: text.slice(0, 500) });
+        await this.teardown(dbRecordId, containerId, tag, entityId);
+        return;
+      }
+
+      // 4. Parse SSE result
+      const body = await res.text();
+      const sseEvents = body
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => {
+          try {
+            return JSON.parse(line.slice(5)) as Record<string, unknown>;
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean) as Array<Record<string, unknown>>;
+
+      const resultEvent = sseEvents.find((e) => e.type === "result");
+      if (!resultEvent) {
+        logger.error(`${tag} no result in SSE stream`, { entityId });
+        await this.teardown(dbRecordId, containerId, tag, entityId);
+        return;
+      }
+
+      const signal = (resultEvent.signal as string) ?? "";
+      const resultArtifacts = (resultEvent.artifacts as Record<string, unknown>) ?? {};
+
+      logger.info(`${tag} dispatch complete`, {
+        entityId,
+        signal,
+        artifactKeys: Object.keys(resultArtifacts),
+        costUsd: resultEvent.costUsd,
+      });
+
+      // 5. Feed signal to engine — gate evaluation hits the still-running container
+      if (signal) {
+        await this.engine.processSignal(entityId, signal, resultArtifacts);
+        logger.info(`${tag} signal processed`, { entityId, signal });
+      } else {
+        logger.warn(`${tag} no signal`, { entityId });
+      }
+    } catch (err) {
+      logger.error(`${tag} dispatch failed`, { entityId, error: err instanceof Error ? err.message : String(err) });
+    }
+
+    // 6. Teardown — processSignal is sync so gates are done
+    await this.teardown(dbRecordId, containerId, tag, entityId);
+  }
+
+  private async teardown(dbRecordId: string, containerId: string, tag: string, entityId: string): Promise<void> {
+    try {
+      await this.fleetManager.teardown(containerId);
+    } catch (err) {
+      logger.warn(`${tag} teardown failed`, { entityId, error: err instanceof Error ? err.message : String(err) });
+    }
+    await this.db
+      .update(holyshipperContainers)
+      .set({ status: "torn_down", tornDownAt: new Date(), updatedAt: new Date() })
+      .where(eq(holyshipperContainers.id, dbRecordId));
+    logger.info(`${tag} teardown complete`, { entityId });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,7 +359,7 @@ async function main() {
   // Start reaper
   const stopReaper = engine.startReaper(30_000);
 
-  // ─── 9b. Holyshipper fleet lifecycle (ephemeral containers) ────────
+  // ─── 9b. Reactive worker pool (ephemeral holyshipper containers) ───
   if (config.HOLYSHIP_WORKER_IMAGE && config.HOLYSHIP_GATEWAY_KEY) {
     try {
       const Docker = (await import("dockerode")).default;
@@ -379,13 +379,14 @@ async function main() {
         network: config.DOCKER_NETWORK,
       });
 
-      const { EntityLifecycleManager } = await import("./fleet/entity-lifecycle.js");
-      const lifecycleManager = new EntityLifecycleManager(
-        engineDb,
+      const { WorkerPool } = await import("./fleet/worker-pool.js");
+      const workerPool = new WorkerPool({
+        engine,
+        db: engineDb,
         tenantId,
-        holyshipperFleet,
-        repos.entities,
-        async () => {
+        fleetManager: holyshipperFleet,
+        invocationRepo: repos.invocations,
+        getGithubToken: async () => {
           if (!hasGitHubApp) return null;
           const installations = await installationRepo.listByTenant(tenantId);
           if (installations.length === 0) return null;
@@ -396,15 +397,16 @@ async function main() {
           );
           return token;
         },
-      );
+        poolSize: 4,
+      });
 
-      eventEmitter.register(lifecycleManager);
-      logger.info("Holyshipper fleet lifecycle registered (ephemeral containers)");
+      eventEmitter.register(workerPool);
+      logger.info("Reactive worker pool registered (4 slots)");
     } catch (err) {
-      logger.warn("Holyshipper fleet lifecycle setup failed (non-fatal)", (err as Error).message);
+      logger.warn("Worker pool setup failed (non-fatal)", (err as Error).message);
     }
   } else {
-    logger.info("Holyshipper fleet lifecycle disabled (HOLYSHIP_WORKER_IMAGE or HOLYSHIP_GATEWAY_KEY not set)");
+    logger.info("Worker pool disabled (HOLYSHIP_WORKER_IMAGE or HOLYSHIP_GATEWAY_KEY not set)");
   }
 
   // ─── 10. Engine REST routes (claim/report for holyshippers) ────────


### PR DESCRIPTION
## Summary
- Replace `EntityLifecycleManager` with `WorkerPool` as the `IEventBusAdapter`
- Purely reactive: invocation.created event → worker takes it → full lifecycle
- Bounded concurrency (4 slots), events queue when busy, drain as slots free
- Each worker: provision container → dispatch prompt → parse signal → processSignal → teardown
- Runner URL persisted to DB for gate delegation (container stays alive through gate eval)

## Test plan
- [ ] `npm run check` passes
- [ ] `npm run build` succeeds
- [ ] Without HOLYSHIP_WORKER_IMAGE, logs "Worker pool disabled" and boots normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a reactive worker pool to handle invocation execution via ephemeral holyshipper containers with bounded concurrency.

New Features:
- Add a WorkerPool event bus adapter that reacts to invocation.created events and runs the full container-based invocation lifecycle end-to-end.

Enhancements:
- Replace the previous EntityLifecycleManager wiring with the new WorkerPool, including updated logging and configuration of a fixed pool size for concurrent workers.
- Persist holyshipper container lifecycle details, including runner URL, to the database to support gate evaluation while containers remain alive.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reactive worker pool for invocation execution
> - Introduces [`WorkerPool`](https://github.com/wopr-network/holyship/pull/204/files#diff-47dd032f7a63551265361fa00520d8c438f2242ad6a70494d352152275f3a9bf), an event bus adapter that subscribes to `invocation.created` events and processes each invocation through a bounded concurrency pipeline (default 4 slots, FIFO queue for overflow).
> - For each invocation, the pool reads the prompt/artifacts from `invocationRepo`, provisions an ephemeral container via `IFleetManager`, dispatches the prompt via HTTP POST `/dispatch` with a model tier derived from the agent role, parses the SSE response, calls `engine.processSignal`, then tears down the container.
> - Replaces the previous `EntityLifecycleManager` registration in [`src/index.ts`](https://github.com/wopr-network/holyship/pull/204/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) with the new `WorkerPool` (active when `HOLYSHIP_WORKER_IMAGE` and `HOLYSHIP_GATEWAY_KEY` are set).
> - Risk: container teardown and signal processing are synchronous within each worker slot; a stalled HTTP dispatch or slow `processSignal` will hold a slot until completion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 509ac8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->