### PR TITLE
feat: test model tier override for free-model testing

### DIFF
--- a/src/fleet/worker-pool.ts
+++ b/src/fleet/worker-pool.ts
@@ -27,6 +27,9 @@ const AGENT_ROLE_TO_TIER: Record<string, string> = {
   "wopr-technical-writer": "haiku",
 };
 
+/** When set, overrides all tier selections — use "test" for free models in dev/staging */
+const MODEL_TIER_OVERRIDE = process.env.HOLYSHIP_MODEL_TIER_OVERRIDE ?? "";
+
 export interface WorkerPoolConfig {
   engine: Engine;
   db: Db;
@@ -158,7 +161,7 @@ export class WorkerPool implements IEventBusAdapter {
     }
 
     // 3. Dispatch prompt
-    const modelTier = AGENT_ROLE_TO_TIER[agentRole ?? ""] ?? "sonnet";
+    const modelTier = MODEL_TIER_OVERRIDE || AGENT_ROLE_TO_TIER[agentRole ?? ""] || "sonnet";
     logger.info(`${tag} dispatching`, { entityId, invocationId, modelTier, promptLength: prompt.length });
 
     try {


### PR DESCRIPTION
## Summary
- Adds `HOLYSHIP_MODEL_TIER_OVERRIDE` env var to worker pool
- When set to `test`, all dispatches use the `test` tier (free model) instead of role-based tiers
- Unset in production = zero behavior change
- Prevents burning Sonnet/Opus credits during smoke testing

## Test plan
- [x] `npm run check` passes
- [ ] CI green

## Summary by Sourcery

New Features:
- Introduce a HOLYSHIP_MODEL_TIER_OVERRIDE environment variable to force all worker dispatches to use a specified model tier when set.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `HOLYSHIP_MODEL_TIER_OVERRIDE` env var to globally override model tier selection
> Adds a `MODEL_TIER_OVERRIDE` constant in [worker-pool.ts](https://github.com/wopr-network/holyship/pull/206/files#diff-47dd032f7a63551265361fa00520d8c438f2242ad6a70494d352152275f3a9bf) that reads `process.env.HOLYSHIP_MODEL_TIER_OVERRIDE`. When set, it takes precedence over the per-role tier lookup in `WorkerPool.runWorker`. Setting it to `"test"` routes all agents to free models, useful in dev/staging. Behavioral Change: the fallback chain switches from nullish coalescing (`??`) to logical OR (`||`), so falsy mapped values like empty strings now fall through to `"sonnet"` instead of being used as-is.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1686749.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable support to override model tier selection for worker dispatch, allowing dynamic configuration of model assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->