### PR TITLE
fix: worker pool claims work on entity.created

### DIFF
--- a/src/fleet/worker-pool.ts
+++ b/src/fleet/worker-pool.ts
@@ -64,6 +64,13 @@ export class WorkerPool implements IEventBusAdapter {
   }
 
   async emit(event: EngineEvent): Promise<void> {
+    // When an entity is created, claim it to build the first invocation
+    if (event.type === "entity.created") {
+      logger.info("[worker-pool] entity.created — claiming work", { entityId: event.entityId });
+      await this.engine.claimWork("engineering");
+      return;
+    }
+
     if (event.type !== "invocation.created") return;
     if ("mode" in event && event.mode === "passive") return;
 


### PR DESCRIPTION
## Summary
- Worker pool now reacts to `entity.created` events by calling `engine.claimWork()`
- This bridges the gap: `createEntity` emits `entity.created`, `claimWork` builds the invocation and emits `invocation.created`, which the worker pool already handles
- Without this, entities created via admin API sat unclaimed forever

## Test plan
- [x] `npm run check` passes
- [ ] CI green
- [ ] Smoke test: POST /api/entities → worker pool logs claim → provisions container

## Summary by Sourcery

Bug Fixes:
- Ensure entities created via the admin API are claimed by the worker pool instead of remaining unprocessed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger `claimWork` on `entity.created` events in `WorkerPool.emit`
> Adds an early-exit branch in [`WorkerPool.emit`](https://github.com/wopr-network/holyship/pull/209/files#diff-47dd032f7a63551265361fa00520d8c438f2242ad6a70494d352152275f3a9bf) to handle `entity.created` events by calling `this.engine.claimWork("engineering")` and returning before any worker start or queue logic runs. Previously, `entity.created` events had no handling in this method.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba5544b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->