### PR TITLE
fix: worker pool directly schedules worker after claimWork

### DIFF
--- a/src/fleet/worker-pool.ts
+++ b/src/fleet/worker-pool.ts
@@ -73,16 +73,34 @@ export class WorkerPool implements IEventBusAdapter {
       entityId: "entityId" in event ? event.entityId : undefined,
     });
 
-    // When an entity is created, claim it to build the first invocation
+    // When an entity is created, claim it and directly schedule the worker.
+    // claimWork emits entity.claimed but NOT invocation.created, so we
+    // synthesize the event and feed it into the pool ourselves.
     if (event.type === "entity.created") {
       logger.info("[worker-pool] entity.created — claiming work", { entityId: event.entityId });
       try {
         const claimed = await this.engine.claimWork("engineering");
         if (claimed && typeof claimed === "object") {
-          logger.info("[worker-pool] claimWork succeeded", {
+          logger.info("[worker-pool] claimWork succeeded — scheduling worker directly", {
             claimedEntityId: claimed.entityId,
             invocationId: claimed.invocationId,
           });
+          const syntheticEvent = {
+            type: "invocation.created" as const,
+            entityId: claimed.entityId,
+            invocationId: claimed.invocationId,
+            stage: claimed.stage,
+            emittedAt: new Date(),
+          };
+          if (this.activeWorkers < this.poolSize) {
+            void this.runWorker(syntheticEvent);
+          } else {
+            this.pending.push(syntheticEvent);
+            logger.warn("[worker-pool] all slots busy — queued claimed work", {
+              entityId: claimed.entityId,
+              queueDepth: this.pending.length,
+            });
+          }
         } else {
           logger.warn("[worker-pool] claimWork returned no work", {
             entityId: event.entityId,


### PR DESCRIPTION
## Summary
- Root cause found: `claimWork` emits `entity.claimed` but NOT `invocation.created`
- The worker pool was waiting for `invocation.created` which never comes for initial invocations
- Now after `claimWork` succeeds, synthesizes the event and passes directly to `runWorker`
- This is THE fix that makes the reactive pipeline work end-to-end

## Test plan
- [x] `npm run check` passes
- [ ] CI green
- [ ] Smoke test: POST /api/entities → logs show worker starting → provision → dispatch

## Summary by Sourcery

Bug Fixes:
- Fix worker pool stalling on initial entity invocations by directly scheduling work after claimWork.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Schedule worker directly in `WorkerPool` after `claimWork` instead of waiting for external event
> Previously, `WorkerPool` waited for an external `invocation.created` event to schedule work after claiming it. Now, on `entity.created`, the pool synthesizes an `invocation.created` event internally using the claimed `entityId`, `invocationId`, and `stage`, then immediately calls `runWorker` (or enqueues if at capacity).
>
> - Behavioral Change: Work scheduling no longer depends on an external `invocation.created` event being emitted after `claimWork`; the pool drives scheduling itself.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b20417.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->