### PR TITLE
feat: use createAndStart + network + ephemeral (platform-core 1.38)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@scure/bip39": "^2.0.1",
     "@sentry/node": "^9.27.0",
     "@trpc/server": "^11.13.4",
-    "@wopr-network/platform-core": "^1.37.0",
+    "@wopr-network/platform-core": "^1.38.0",
     "dockerode": "^4.0.9",
     "drizzle-orm": "^0.45.1",
     "handlebars": "^4.7.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^11.13.4
         version: 11.13.4(typescript@5.9.3)
       '@wopr-network/platform-core':
-        specifier: ^1.37.0
-        version: 1.37.0(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)
+        specifier: ^1.38.0
+        version: 1.38.0(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)
       dockerode:
         specifier: ^4.0.9
         version: 4.0.9
@@ -1286,8 +1286,8 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
-  '@wopr-network/platform-core@1.37.0':
-    resolution: {integrity: sha512-RZoNThAK32qZaau6K8g/hajqaAezRzR8TQdIPmv/wZq/TU0tAQGt+JI92k+rnpgSc6VAEWMssX4LDPKY5Zc8Xw==}
+  '@wopr-network/platform-core@1.38.0':
+    resolution: {integrity: sha512-oG08rNRV+DmoCJ39QRYRH00N/090HgNon5/V+xbGuf98FVCdaxlajXJKgn1L2sOIUbqk0baOHQSnZ3sLuo6yeA==}
     peerDependencies:
       '@trpc/server': '>=11'
       better-auth: '>=1.5'
@@ -3446,7 +3446,7 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@wopr-network/platform-core@1.37.0(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)':
+  '@wopr-network/platform-core@1.38.0(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.12)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)':
     dependencies:
       '@noble/hashes': 2.0.1
       '@scure/base': 2.0.0

--- a/src/fleet/holyshipper-fleet-manager.ts
+++ b/src/fleet/holyshipper-fleet-manager.ts
@@ -74,8 +74,8 @@ export class HolyshipperFleetManager implements IFleetManager {
       env.GITHUB_TOKEN = config.githubToken;
     }
 
-    // Create ephemeral container via platform-core FleetManager
-    const profile = await this.fleet.create({
+    // Create + start ephemeral container via platform-core FleetManager
+    const profile = await this.fleet.createAndStart({
       id: profileId,
       name: botName,
       tenantId: "holyship",
@@ -85,6 +85,8 @@ export class HolyshipperFleetManager implements IFleetManager {
       description: `Ephemeral worker for entity ${entityId}`,
       updatePolicy: "manual",
       releaseChannel: "stable",
+      network: this.network,
+      ephemeral: true,
     });
 
     const containerId = profile.id;


### PR DESCRIPTION
## Summary
- Uses `createAndStart()` — container starts immediately after creation
- Passes `network` for Docker DNS resolution between API and holyshipper workers
- Sets `ephemeral: true` — writable filesystem for /workspace, /home
- Bumps platform-core to 1.38.0

Fixes: container was "Created" but never started, on wrong network, with readonly filesystem.

## Test plan
- [x] `npm run check` passes
- [ ] CI green
- [ ] Smoke test: container starts, joins compose network, health check passes

## Summary by Sourcery

Start ephemeral holyshipper worker containers immediately on creation using the updated platform-core fleet manager.

New Features:
- Start holyshipper worker containers via the fleet manager using createAndStart with an attached network and ephemeral writable filesystem.

Enhancements:
- Pass the configured Docker network to worker containers to enable DNS resolution between services.
- Upgrade @wopr-network/platform-core dependency to version 1.38.0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `createAndStart` with network and ephemeral options in `HolyshipperFleetManager.provision`
> Updates `HolyshipperFleetManager.provision` in [holyshipper-fleet-manager.ts](https://github.com/wopr-network/holyship/pull/215/files#diff-443adb71a30642a483836e56957260945f1bfdd062a456fd671df5c7f4ce643d) to call `this.fleet.createAndStart(...)` instead of `this.fleet.create(...)`, and adds `network: this.network` and `ephemeral: true` to the profile options. Also bumps `@wopr-network/platform-core` to `^1.38.0` to support these new options. Behavioral Change: containers are now started immediately on provisioning, attached to the configured network, and marked ephemeral (auto-removed on stop).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e5da37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->