### PR TITLE
fix: wopr- prefix in container DNS name

### DIFF
--- a/src/fleet/holyshipper-fleet-manager.ts
+++ b/src/fleet/holyshipper-fleet-manager.ts
@@ -132,10 +132,10 @@ export class HolyshipperFleetManager implements IFleetManager {
     const start = Date.now();
     const interval = 1000;
 
-    // For now, construct URL from container name + network
-    // In production this would inspect the container for the mapped port
+    // FleetManager prefixes container names with "wopr-"
+    const containerDns = `wopr-${botName.replace(/_/g, "-")}`;
     const runnerUrl = this.network
-      ? `http://${botName}:${this.containerPort}`
+      ? `http://${containerDns}:${this.containerPort}`
       : `http://localhost:${this.containerPort}`;
 
     while (Date.now() - start < timeoutMs) {


### PR DESCRIPTION
## Summary
- FleetManager names containers `wopr-{name}` but health check URL used `{name}` without prefix
- Docker DNS couldn't resolve → 30s timeout on every provision
- Now constructs URL as `http://wopr-{botName}:{port}`

## Test plan
- [x] `npm run check` passes
- [ ] CI green
- [ ] Smoke test: health check passes → dispatch begins

## Summary by Sourcery

Bug Fixes:
- Resolve container health check timeouts by constructing the runner URL with the correct wopr- prefixed container DNS name.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix container DNS name to use `wopr-` prefix in `HolyshipperFleetManager.waitForReady`
> When a Docker network is configured, the health probe and runner URL were targeting `http://<botName>:<port>`, but container DNS names require the `wopr-` prefix. The fix derives the DNS hostname as `wopr-<botName>` with underscores replaced by hyphens, matching actual container naming conventions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0670e74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->