### PR TITLE
feat: repo interrogation prompt + parser

### DIFF
--- a/src/flows/interrogation-prompt.ts
+++ b/src/flows/interrogation-prompt.ts
@@ -1,0 +1,239 @@
+/**
+ * Repo Interrogation Prompt Template.
+ *
+ * Dispatched to a runner when a repo is onboarded. The AI inspects the repo,
+ * produces a structured RepoConfig, identifies gaps, and bootstraps a CLAUDE.md.
+ *
+ * This is not a flow state — it's a one-shot dispatch that runs before any flow exists.
+ * The output drives which flow gets designed for this repo.
+ */
+
+export const INTERROGATION_PROMPT = `You are a repo analyst. Your job is to thoroughly inspect this repository and produce a structured capabilities report.
+
+## Repo
+{{repoFullName}}
+
+## Phase 1: File Inspection
+
+Scan the repo for the following. Be thorough — check root and subdirectories.
+
+**Structure:**
+- Is this a monorepo? Check for: pnpm-workspace.yaml, lerna.json, nx.json, turbo.json, workspaces in package.json
+- If monorepo, list each package/workspace and what it does
+- What languages are used? Check file extensions and config files
+
+**Package Manager:**
+- Which lockfile exists? (pnpm-lock.yaml, package-lock.json, yarn.lock, Cargo.lock, go.sum, poetry.lock, requirements.txt)
+
+**Testing:**
+- Are there test files? Where? (look for *.test.*, *.spec.*, test/, tests/, __tests__/)
+- What framework? (vitest.config.*, jest.config.*, pytest.ini, pyproject.toml [pytest section])
+- Is coverage configured? What thresholds?
+- What command runs the tests? (check package.json scripts, Makefile, etc.)
+
+**CI/CD:**
+- Is there CI? Check .github/workflows/, .circleci/, Jenkinsfile, .gitlab-ci.yml, bitbucket-pipelines.yml
+- What checks run? (lint, build, test, security, etc.)
+- Is there a merge queue configured?
+- What are the required status checks?
+
+**Code Quality:**
+- Linter? (biome.json, .eslintrc*, ruff.toml, .golangci.yml, .rubocop.yml)
+- Formatter? (prettier in deps, biome, .editorconfig, rustfmt.toml, black in pyproject)
+- Type checking? (tsconfig.json, mypy.ini, pyrightconfig.json)
+
+**Build:**
+- How do you build? (check scripts in package.json, Makefile, Dockerfile, docker-compose.yml)
+- Does the build produce artifacts?
+
+**VCS & Reviews:**
+- Default branch name?
+- CODEOWNERS file?
+- PR template?
+- Issue templates?
+- Review bots? Check for: .coderabbit.yaml, .sourcery.yaml, .greptile/, dependabot.yml, renovate.json
+- Also check recent PR comments/reviews for bot usernames (coderabbitai[bot], sourcery-ai[bot], etc.)
+
+**Documentation:**
+- docs/ directory?
+- README.md — how detailed is it?
+- CHANGELOG.md?
+- API docs (generated or manual)?
+
+**Security:**
+- .env.example present?
+- SECURITY.md?
+- Secret scanning or CodeQL configured?
+- Dependency update bot (dependabot.yml, renovate.json)?
+
+**Project Intelligence:**
+- CLAUDE.md present? Read it carefully — it contains the repo's conventions, CI gate commands, and gotchas.
+- AGENTS.md? .cursorrules? .github/copilot-instructions.md?
+- Conventional commits? (check recent commit messages for patterns like feat:, fix:, chore:)
+
+**Spec Management:**
+- Where do specs/issues live? (GitHub Issues, docs/specs/, docs/adr/, docs/rfc/)
+- Issue templates present?
+- How are PRs linked to issues? (branch naming conventions, "Closes #X" in commits)
+
+## Phase 2: Judgment Calls
+
+Based on what you found, answer:
+1. What does this repo actually do? (one paragraph)
+2. What's the full CI gate command? (the exact sequence to run before committing)
+3. What are the repo's conventions that an engineer must follow?
+4. What's fragile or unusual? (scan for TODO, FIXME, HACK comments; check CLAUDE.md gotchas)
+5. If monorepo: do capabilities differ per package?
+
+## Output
+
+You MUST output a JSON block with the following schema. Output it on a line starting with \`REPO_CONFIG:\` followed by the JSON. Do not wrap in markdown code fences.
+
+REPO_CONFIG:{"repo":"org/name","defaultBranch":"main","description":"...","languages":["typescript"],"monorepo":false,"packages":[],"ci":{"supported":true,"provider":"github-actions","gateCommand":"pnpm lint && pnpm build && pnpm test","hasMergeQueue":false,"requiredChecks":["build","test"]},"testing":{"supported":true,"framework":"vitest","runCommand":"pnpm test","hasCoverage":true,"coverageThreshold":98},"linting":{"supported":true,"tool":"biome","runCommand":"pnpm lint"},"formatting":{"supported":true,"tool":"biome","runCommand":"pnpm format"},"typeChecking":{"supported":true,"tool":"tsc","runCommand":"pnpm check"},"build":{"supported":true,"runCommand":"pnpm build","producesArtifacts":true,"dockerfile":false},"reviewBots":{"supported":false,"bots":[]},"docs":{"supported":false,"location":null,"hasApiDocs":false},"specManagement":{"tracker":"github-issues","specLocation":"issue-comments","hasTemplates":false},"security":{"hasEnvExample":false,"hasSecurityPolicy":false,"hasSecretScanning":false,"hasDependencyUpdates":false},"intelligence":{"hasClaudeMd":false,"hasAgentsMd":false,"conventions":[],"ciGateCommand":null}}
+
+After the REPO_CONFIG, output a gaps section. For each missing capability, output a line starting with \`GAP:\` followed by JSON:
+
+GAP:{"capability":"ci","title":"Set up CI pipeline","priority":"high","description":"No CI configuration found. Add GitHub Actions workflows for lint, build, and test."}
+GAP:{"capability":"testing","title":"Add test framework and initial tests","priority":"high","description":"No test files or test framework configuration found."}
+
+Only output GAPs for capabilities where supported is false or important sub-capabilities are missing.
+
+Finally, if no CLAUDE.md exists, output a \`CLAUDE_MD:\` line followed by the full contents of a bootstrapped CLAUDE.md for this repo, based on everything you learned. If one already exists, output \`CLAUDE_MD:EXISTS\`.
+
+interrogation_complete`;
+
+/**
+ * Parse the interrogation output into structured data.
+ */
+export interface RepoConfig {
+  repo: string;
+  defaultBranch: string;
+  description: string;
+  languages: string[];
+  monorepo: boolean;
+  packages?: { name: string; path: string; description: string }[];
+  ci: {
+    supported: boolean;
+    provider?: string;
+    gateCommand?: string;
+    hasMergeQueue?: boolean;
+    requiredChecks?: string[];
+  };
+  testing: {
+    supported: boolean;
+    framework?: string;
+    runCommand?: string;
+    hasCoverage?: boolean;
+    coverageThreshold?: number;
+  };
+  linting: {
+    supported: boolean;
+    tool?: string;
+    runCommand?: string;
+  };
+  formatting: {
+    supported: boolean;
+    tool?: string;
+    runCommand?: string;
+  };
+  typeChecking: {
+    supported: boolean;
+    tool?: string;
+    runCommand?: string;
+  };
+  build: {
+    supported: boolean;
+    runCommand?: string;
+    producesArtifacts?: boolean;
+    dockerfile?: boolean;
+  };
+  reviewBots: {
+    supported: boolean;
+    bots?: string[];
+  };
+  docs: {
+    supported: boolean;
+    location?: string | null;
+    hasApiDocs?: boolean;
+  };
+  specManagement: {
+    tracker: string;
+    specLocation?: string;
+    hasTemplates?: boolean;
+  };
+  security: {
+    hasEnvExample?: boolean;
+    hasSecurityPolicy?: boolean;
+    hasSecretScanning?: boolean;
+    hasDependencyUpdates?: boolean;
+  };
+  intelligence: {
+    hasClaudeMd: boolean;
+    hasAgentsMd: boolean;
+    conventions: string[];
+    ciGateCommand?: string | null;
+  };
+}
+
+export interface Gap {
+  capability: string;
+  title: string;
+  priority: "high" | "medium" | "low";
+  description: string;
+}
+
+export interface InterrogationResult {
+  config: RepoConfig;
+  gaps: Gap[];
+  claudeMd: string | null; // null means CLAUDE.md already exists
+}
+
+/**
+ * Parse raw AI output into structured InterrogationResult.
+ * Scans lines for REPO_CONFIG:, GAP:, and CLAUDE_MD: prefixes.
+ */
+export function parseInterrogationOutput(output: string): InterrogationResult {
+  const lines = output.split("\n");
+
+  let config: RepoConfig | null = null;
+  const gaps: Gap[] = [];
+  let claudeMd: string | null = null;
+  let inClaudeMd = false;
+  const claudeMdLines: string[] = [];
+
+  for (const line of lines) {
+    if (inClaudeMd) {
+      // Everything after CLAUDE_MD: until end is the CLAUDE.md content
+      // (unless we hit interrogation_complete signal)
+      if (line.trim() === "interrogation_complete") break;
+      claudeMdLines.push(line);
+      continue;
+    }
+
+    if (line.startsWith("REPO_CONFIG:")) {
+      const json = line.slice("REPO_CONFIG:".length).trim();
+      config = JSON.parse(json) as RepoConfig;
+    } else if (line.startsWith("GAP:")) {
+      const json = line.slice("GAP:".length).trim();
+      gaps.push(JSON.parse(json) as Gap);
+    } else if (line.startsWith("CLAUDE_MD:")) {
+      const rest = line.slice("CLAUDE_MD:".length).trim();
+      if (rest === "EXISTS") {
+        claudeMd = null;
+      } else {
+        inClaudeMd = true;
+        if (rest) claudeMdLines.push(rest);
+      }
+    }
+  }
+
+  if (inClaudeMd && claudeMdLines.length > 0) {
+    claudeMd = claudeMdLines.join("\n").trim();
+  }
+
+  if (!config) {
+    throw new Error("Interrogation output missing REPO_CONFIG line");
+  }
+
+  return { config, gaps, claudeMd };
+}

--- a/tests/flows/interrogation-prompt.test.ts
+++ b/tests/flows/interrogation-prompt.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { parseInterrogationOutput } from "../../src/flows/interrogation-prompt.js";
+
+describe("parseInterrogationOutput", () => {
+  it("parses a complete interrogation output", () => {
+    const output = `Some AI preamble text about inspecting the repo.
+
+REPO_CONFIG:{"repo":"org/my-app","defaultBranch":"main","description":"A web API","languages":["typescript"],"monorepo":false,"ci":{"supported":true,"provider":"github-actions","gateCommand":"pnpm lint && pnpm build && pnpm test","hasMergeQueue":false,"requiredChecks":["build","test"]},"testing":{"supported":true,"framework":"vitest","runCommand":"pnpm test","hasCoverage":true,"coverageThreshold":98},"linting":{"supported":true,"tool":"biome","runCommand":"pnpm lint"},"formatting":{"supported":true,"tool":"biome","runCommand":"pnpm format"},"typeChecking":{"supported":true,"tool":"tsc","runCommand":"pnpm check"},"build":{"supported":true,"runCommand":"pnpm build","producesArtifacts":true,"dockerfile":false},"reviewBots":{"supported":false,"bots":[]},"docs":{"supported":false,"location":null,"hasApiDocs":false},"specManagement":{"tracker":"github-issues","specLocation":"issue-comments","hasTemplates":false},"security":{"hasEnvExample":false,"hasSecurityPolicy":false,"hasSecretScanning":false,"hasDependencyUpdates":false},"intelligence":{"hasClaudeMd":false,"hasAgentsMd":false,"conventions":["conventional-commits"],"ciGateCommand":"pnpm lint && pnpm build && pnpm test"}}
+GAP:{"capability":"reviewBots","title":"Configure review bots","priority":"medium","description":"No review bots configured."}
+GAP:{"capability":"docs","title":"Set up documentation","priority":"low","description":"No docs directory found."}
+GAP:{"capability":"security","title":"Add SECURITY.md","priority":"low","description":"No security policy."}
+CLAUDE_MD:# my-app
+
+## CI Gate
+pnpm lint && pnpm build && pnpm test
+
+## Conventions
+- Conventional commits (feat:, fix:, chore:)
+- biome for lint and format
+
+interrogation_complete`;
+
+    const result = parseInterrogationOutput(output);
+
+    expect(result.config.repo).toBe("org/my-app");
+    expect(result.config.languages).toEqual(["typescript"]);
+    expect(result.config.ci.supported).toBe(true);
+    expect(result.config.ci.gateCommand).toBe("pnpm lint && pnpm build && pnpm test");
+    expect(result.config.testing.framework).toBe("vitest");
+    expect(result.config.reviewBots.supported).toBe(false);
+    expect(result.config.intelligence.conventions).toEqual(["conventional-commits"]);
+
+    expect(result.gaps).toHaveLength(3);
+    expect(result.gaps[0].capability).toBe("reviewBots");
+    expect(result.gaps[0].priority).toBe("medium");
+    expect(result.gaps[1].capability).toBe("docs");
+    expect(result.gaps[2].capability).toBe("security");
+
+    expect(result.claudeMd).toContain("# my-app");
+    expect(result.claudeMd).toContain("pnpm lint && pnpm build && pnpm test");
+  });
+
+  it("handles existing CLAUDE.md", () => {
+    const output = `REPO_CONFIG:{"repo":"org/app","defaultBranch":"main","description":"test","languages":["go"],"monorepo":false,"ci":{"supported":false},"testing":{"supported":false},"linting":{"supported":false},"formatting":{"supported":false},"typeChecking":{"supported":false},"build":{"supported":false},"reviewBots":{"supported":false},"docs":{"supported":false},"specManagement":{"tracker":"github-issues"},"security":{},"intelligence":{"hasClaudeMd":true,"hasAgentsMd":false,"conventions":[],"ciGateCommand":null}}
+CLAUDE_MD:EXISTS
+
+interrogation_complete`;
+
+    const result = parseInterrogationOutput(output);
+
+    expect(result.config.repo).toBe("org/app");
+    expect(result.config.intelligence.hasClaudeMd).toBe(true);
+    expect(result.claudeMd).toBeNull();
+    expect(result.gaps).toHaveLength(0);
+  });
+
+  it("handles no gaps", () => {
+    const output = `REPO_CONFIG:{"repo":"org/perfect","defaultBranch":"main","description":"fully configured","languages":["typescript"],"monorepo":false,"ci":{"supported":true},"testing":{"supported":true},"linting":{"supported":true},"formatting":{"supported":true},"typeChecking":{"supported":true},"build":{"supported":true},"reviewBots":{"supported":true},"docs":{"supported":true},"specManagement":{"tracker":"github-issues"},"security":{"hasEnvExample":true,"hasSecurityPolicy":true,"hasSecretScanning":true,"hasDependencyUpdates":true},"intelligence":{"hasClaudeMd":true,"hasAgentsMd":false,"conventions":["conventional-commits"],"ciGateCommand":"pnpm lint && pnpm build && pnpm test"}}
+CLAUDE_MD:EXISTS
+
+interrogation_complete`;
+
+    const result = parseInterrogationOutput(output);
+
+    expect(result.config.repo).toBe("org/perfect");
+    expect(result.gaps).toHaveLength(0);
+    expect(result.claudeMd).toBeNull();
+  });
+
+  it("throws on missing REPO_CONFIG", () => {
+    const output = `Just some text with no config.
+
+interrogation_complete`;
+
+    expect(() => parseInterrogationOutput(output)).toThrow("missing REPO_CONFIG");
+  });
+
+  it("handles multiline CLAUDE.md content", () => {
+    const output = `REPO_CONFIG:{"repo":"org/app","defaultBranch":"main","description":"test","languages":["python"],"monorepo":false,"ci":{"supported":false},"testing":{"supported":false},"linting":{"supported":false},"formatting":{"supported":false},"typeChecking":{"supported":false},"build":{"supported":false},"reviewBots":{"supported":false},"docs":{"supported":false},"specManagement":{"tracker":"github-issues"},"security":{},"intelligence":{"hasClaudeMd":false,"hasAgentsMd":false,"conventions":[],"ciGateCommand":null}}
+CLAUDE_MD:# My Python App
+
+## Setup
+pip install -r requirements.txt
+
+## Testing
+pytest
+
+## Gotchas
+- Always run black before committing
+- The ML pipeline takes 20 minutes
+
+interrogation_complete`;
+
+    const result = parseInterrogationOutput(output);
+
+    expect(result.claudeMd).toContain("# My Python App");
+    expect(result.claudeMd).toContain("pip install -r requirements.txt");
+    expect(result.claudeMd).toContain("ML pipeline takes 20 minutes");
+  });
+});


### PR DESCRIPTION
## Summary

- Prompt template for repo onboarding — dispatched to runner to inspect repo and produce structured config
- Parser extracts `REPO_CONFIG:`, `GAP:`, and `CLAUDE_MD:` from AI output
- 5 tests covering full output, existing CLAUDE.md, no gaps, missing config, multiline content

Implements the interrogation step from the design spec merged in #219.

## Test plan

- [x] 5 tests passing
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a repository interrogation prompt and parser for onboarding analysis output into structured configuration, along with tests covering parsing scenarios.

New Features:
- Introduce a prompt template for repository interrogation that guides AI to produce structured repo configuration, capability gaps, and optional CLAUDE.md content.
- Add a parser that extracts structured repo configuration, capability gaps, and CLAUDE.md content from interrogation output.

Tests:
- Add unit tests covering full interrogation output, existing CLAUDE.md handling, missing gaps, missing configuration error, and multiline CLAUDE.md content parsing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add repo interrogation prompt and output parser
> - Adds `INTERROGATION_PROMPT` in [interrogation-prompt.ts](https://github.com/wopr-network/holyship/pull/220/files#diff-d9a709b2144adc9789e3533d5d3c9fe000904a884aa1d9eb7eb75be6ac11a820), a structured prompt instructing an AI to inspect a repository and emit `REPO_CONFIG:`, `GAP:`, and `CLAUDE_MD:` prefixed lines terminated by `interrogation_complete`.
> - Adds `parseInterrogationOutput` which parses that AI output into a typed `InterrogationResult` containing a `RepoConfig` object, an array of `Gap` items, and optional multiline CLAUDE.md content; throws if `REPO_CONFIG` is absent.
> - Adds a vitest suite in [interrogation-prompt.test.ts](https://github.com/wopr-network/holyship/pull/220/files#diff-a7e2d14260dded95c3a19d4941515a6ee995e70338183f71944d75d00ce9462c) covering complete output, `CLAUDE_MD:EXISTS`, missing gaps, missing `REPO_CONFIG`, and multiline CLAUDE.md capture.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0673d42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->