### PR TITLE
feat: flow edit prompt + parser (renderFlowEditPrompt / parseFlowEditOutput)

### DIFF
--- a/src/flows/flow-edit-prompt.ts
+++ b/src/flows/flow-edit-prompt.ts
@@ -1,0 +1,146 @@
+/**
+ * Flow Edit Prompt Template.
+ *
+ * Dispatched to a runner when a user wants to modify an existing flow via natural language.
+ * The AI edits the YAML based on the user's request and outputs structured markers.
+ *
+ * Similar pattern to interrogation-prompt.ts — line-prefix markers for structured parsing.
+ */
+
+import type { RepoConfig } from "./interrogation-prompt.js";
+
+/**
+ * Build the LLM prompt for conversational flow editing.
+ *
+ * @param currentYaml - The current flow YAML (may be empty for new flows)
+ * @param userMessage - What the user wants to change
+ * @param repoConfig - Optional repo context to inform the edit
+ */
+export function renderFlowEditPrompt(currentYaml: string, userMessage: string, repoConfig?: RepoConfig): string {
+  const repoSection = repoConfig
+    ? `## Repo Context
+Repo: ${repoConfig.repo}
+Branch: ${repoConfig.defaultBranch}
+CI gate: ${repoConfig.ci.gateCommand ?? "unknown"}
+Languages: ${repoConfig.languages.join(", ")}
+
+`
+    : "";
+
+  const yamlSection = currentYaml.trim()
+    ? `## Current Flow YAML
+${currentYaml.trim()}
+
+`
+    : `## Current Flow YAML
+(empty — this is a new flow)
+
+`;
+
+  return `You are a flow editor. Your job is to modify a flow definition YAML based on the user's request.
+
+A flow is a directed graph of states, transitions, and gates that guides an AI agent through a software engineering task.
+
+${repoSection}${yamlSection}## User Request
+${userMessage}
+
+## Instructions
+
+1. Analyse the current YAML and understand what the user wants to change.
+2. Apply the requested changes. If the YAML is empty, create a new flow from scratch.
+3. Preserve any existing states, transitions, or gates that the user has NOT asked to change.
+4. Use valid YAML — indentation must be consistent (2 spaces).
+
+## Output Format
+
+Output the updated YAML starting on the line immediately after \`UPDATED_YAML:\`. Do not wrap in markdown code fences.
+
+UPDATED_YAML:
+name: my-flow
+# ... full YAML here ...
+
+Then output a short description of what you changed, starting with \`EXPLANATION:\`:
+
+EXPLANATION: Added a review state between coding and merging, with a gate that checks CI status.
+
+Then output a list of specific changes (one per line), prefixed with \`+\` (added), \`~\` (modified), or \`-\` (removed), starting with \`DIFF:\`:
+
+DIFF:
++ state: review
+~ transition: coding → review (was coding → merging)
+- gate: skip-review
+
+End with the signal:
+
+edit_complete`;
+}
+
+/**
+ * Result of parsing LLM flow-edit output.
+ */
+export interface FlowEditResult {
+  updatedYaml: string;
+  explanation: string;
+  diff: string[];
+}
+
+/**
+ * Parse raw LLM output from a flow-edit dispatch into structured data.
+ * Scans lines for UPDATED_YAML:, EXPLANATION:, and DIFF: prefixes.
+ */
+export function parseFlowEditOutput(raw: string): FlowEditResult {
+  const lines = raw.split("\n");
+
+  let updatedYaml: string | null = null;
+  let explanation = "";
+  const diff: string[] = [];
+
+  type Section = "none" | "yaml" | "diff";
+  let section: Section = "none";
+  const yamlLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.trim() === "edit_complete") break;
+
+    if (line.startsWith("UPDATED_YAML:")) {
+      section = "yaml";
+      const rest = line.slice("UPDATED_YAML:".length);
+      if (rest.trim()) yamlLines.push(rest.trimStart());
+      continue;
+    }
+
+    if (line.startsWith("EXPLANATION:")) {
+      section = "none";
+      if (yamlLines.length > 0) {
+        updatedYaml = yamlLines.join("\n").trim();
+      }
+      explanation = line.slice("EXPLANATION:".length).trim();
+      continue;
+    }
+
+    if (line.startsWith("DIFF:")) {
+      section = "diff";
+      const rest = line.slice("DIFF:".length).trim();
+      if (rest) diff.push(rest);
+      continue;
+    }
+
+    if (section === "yaml") {
+      yamlLines.push(line);
+    } else if (section === "diff") {
+      const trimmed = line.trim();
+      if (trimmed) diff.push(trimmed);
+    }
+  }
+
+  // Flush yaml if EXPLANATION never appeared
+  if (updatedYaml === null && yamlLines.length > 0) {
+    updatedYaml = yamlLines.join("\n").trim();
+  }
+
+  if (!updatedYaml) {
+    throw new Error("Flow edit output missing UPDATED_YAML");
+  }
+
+  return { updatedYaml, explanation, diff };
+}

--- a/tests/flows/flow-edit-prompt.test.ts
+++ b/tests/flows/flow-edit-prompt.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import { parseFlowEditOutput, renderFlowEditPrompt } from "../../src/flows/flow-edit-prompt.js";
+import type { RepoConfig } from "../../src/flows/interrogation-prompt.js";
+
+const minimalRepoConfig: RepoConfig = {
+  repo: "org/my-app",
+  defaultBranch: "main",
+  description: "A web API",
+  languages: ["typescript"],
+  monorepo: false,
+  ci: { supported: true, gateCommand: "pnpm lint && pnpm test" },
+  testing: { supported: true },
+  linting: { supported: true },
+  formatting: { supported: true },
+  typeChecking: { supported: true },
+  build: { supported: true },
+  reviewBots: { supported: false },
+  docs: { supported: false },
+  specManagement: { tracker: "github-issues" },
+  security: {},
+  intelligence: { hasClaudeMd: true, hasAgentsMd: false, conventions: [] },
+};
+
+describe("renderFlowEditPrompt", () => {
+  it("includes userMessage and currentYaml in the output", () => {
+    const yaml = "name: my-flow\nstates:\n  - name: coding";
+    const prompt = renderFlowEditPrompt(yaml, "Add a review state");
+
+    expect(prompt).toContain("Add a review state");
+    expect(prompt).toContain("name: my-flow");
+    expect(prompt).toContain("UPDATED_YAML:");
+    expect(prompt).toContain("EXPLANATION:");
+    expect(prompt).toContain("DIFF:");
+    expect(prompt).toContain("edit_complete");
+  });
+
+  it("indicates new flow when currentYaml is empty", () => {
+    const prompt = renderFlowEditPrompt("", "Create a new flow for code review");
+
+    expect(prompt).toContain("new flow");
+    expect(prompt).toContain("Create a new flow for code review");
+  });
+
+  it("includes repo context when repoConfig is provided", () => {
+    const prompt = renderFlowEditPrompt("name: my-flow", "Add a gate", minimalRepoConfig);
+
+    expect(prompt).toContain("org/my-app");
+    expect(prompt).toContain("pnpm lint && pnpm test");
+    expect(prompt).toContain("typescript");
+  });
+
+  it("omits repo section when repoConfig is not provided", () => {
+    const prompt = renderFlowEditPrompt("name: my-flow", "Add a gate");
+
+    expect(prompt).not.toContain("Repo Context");
+    expect(prompt).not.toContain("CI gate:");
+  });
+});
+
+describe("parseFlowEditOutput", () => {
+  it("parses a complete output with yaml, explanation, and diff", () => {
+    const raw = `I have analysed the flow and made the requested changes.
+
+UPDATED_YAML:
+name: my-flow
+states:
+  - name: coding
+  - name: review
+  - name: merging
+transitions:
+  - from: coding
+    to: review
+  - from: review
+    to: merging
+EXPLANATION: Added a review state between coding and merging.
+DIFF:
++ state: review
+~ transition: coding → merging (now coding → review)
++ transition: review → merging
+
+edit_complete`;
+
+    const result = parseFlowEditOutput(raw);
+
+    expect(result.updatedYaml).toContain("name: my-flow");
+    expect(result.updatedYaml).toContain("- name: review");
+    expect(result.explanation).toBe("Added a review state between coding and merging.");
+    expect(result.diff).toHaveLength(3);
+    expect(result.diff[0]).toBe("+ state: review");
+    expect(result.diff[1]).toBe("~ transition: coding → merging (now coding → review)");
+    expect(result.diff[2]).toBe("+ transition: review → merging");
+  });
+
+  it("parses output with empty diff", () => {
+    const raw = `UPDATED_YAML:
+name: simple-flow
+states:
+  - name: working
+EXPLANATION: Renamed the flow.
+DIFF:
+
+edit_complete`;
+
+    const result = parseFlowEditOutput(raw);
+
+    expect(result.updatedYaml).toContain("name: simple-flow");
+    expect(result.explanation).toBe("Renamed the flow.");
+    expect(result.diff).toHaveLength(0);
+  });
+
+  it("parses output when DIFF has inline content on the same line", () => {
+    const raw = `UPDATED_YAML:
+name: flow
+EXPLANATION: Minor fix.
+DIFF: ~ state name typo fixed
+
+edit_complete`;
+
+    const result = parseFlowEditOutput(raw);
+
+    expect(result.diff).toHaveLength(1);
+    expect(result.diff[0]).toBe("~ state name typo fixed");
+  });
+
+  it("throws on missing UPDATED_YAML", () => {
+    const raw = `EXPLANATION: I tried to edit the flow.
+DIFF:
++ something
+
+edit_complete`;
+
+    expect(() => parseFlowEditOutput(raw)).toThrow("missing UPDATED_YAML");
+  });
+
+  it("handles LLM preamble text before UPDATED_YAML", () => {
+    const raw = `Sure! Here are the changes you requested.
+
+After careful review, I will now output the updated YAML.
+
+UPDATED_YAML:
+name: preamble-flow
+EXPLANATION: Added preamble handling.
+DIFF:
+
+edit_complete`;
+
+    const result = parseFlowEditOutput(raw);
+
+    expect(result.updatedYaml).toBe("name: preamble-flow");
+    expect(result.explanation).toBe("Added preamble handling.");
+  });
+
+  it("stops at edit_complete signal", () => {
+    const raw = `UPDATED_YAML:
+name: my-flow
+EXPLANATION: Done.
+DIFF:
+
+edit_complete
+
+This trailing text should be ignored.`;
+
+    const result = parseFlowEditOutput(raw);
+
+    expect(result.updatedYaml).toBe("name: my-flow");
+  });
+});


### PR DESCRIPTION
## Summary
- `renderFlowEditPrompt` builds LLM prompt for conversational flow editing with optional repo context
- `parseFlowEditOutput` extracts `updatedYaml`, `explanation`, and `diff` from LLM output
- Follows the same marker-prefix pattern as `interrogation-prompt.ts`

Closes #224

## Test plan
- [x] Parses complete output with yaml + explanation + diff
- [x] Parses output with empty diff
- [x] Parses inline diff on same line as DIFF: marker
- [x] Throws on missing UPDATED_YAML
- [x] Handles LLM preamble text before UPDATED_YAML
- [x] Stops at edit_complete signal
- [x] renderFlowEditPrompt includes repo context when provided
- [x] renderFlowEditPrompt omits repo section when repoConfig absent
- [x] renderFlowEditPrompt indicates new flow when currentYaml is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `renderFlowEditPrompt` and `parseFlowEditOutput` for flow YAML editing via LLM
> - [`renderFlowEditPrompt`](https://github.com/wopr-network/holyship/pull/229/files#diff-b7700a794ae2d2677b9e1b606349c8fff0c26e659250d9857b2335046a1dd1f5) builds a structured prompt for editing a flow YAML, including optional repo context, the current YAML (or a note when empty), the user request, and output markers (`UPDATED_YAML:`, `EXPLANATION:`, `DIFF:`, `edit_complete`).
> - [`parseFlowEditOutput`](https://github.com/wopr-network/holyship/pull/229/files#diff-b7700a794ae2d2677b9e1b606349c8fff0c26e659250d9857b2335046a1dd1f5) parses raw LLM responses using those markers into a typed `FlowEditResult` object with `updatedYaml`, `explanation`, and `diff` fields, handling preamble text and inline `DIFF:` content.
> - Throws an error if `UPDATED_YAML` content is absent in the parsed output.
> - Test coverage in [`tests/flows/flow-edit-prompt.test.ts`](https://github.com/wopr-network/holyship/pull/229/files#diff-f2b73379758496d21416c57d2b12160fccb2ca310dde87c4669884138c5202fe) covers prompt construction, parse edge cases, and error handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22e9a45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->