### PR TITLE
feat: GET /repos/:owner/:repo/flow — read .holyship/flow.yml

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { logger } from "./logger.js";
 import type { Entity } from "./repositories/interfaces.js";
 import { createScopedRepos } from "./repositories/scoped-repos.js";
 import { createEngineRoutes } from "./routes/engine.js";
+import { createFlowEditorRoutes } from "./routes/flow-editor.js";
 
 // ---------------------------------------------------------------------------
 // Notification worker handle (for graceful shutdown)
@@ -509,6 +510,26 @@ async function main() {
       }
     });
     logger.info("GitHub repos endpoint mounted");
+  }
+
+  // ─── 12c. Flow editor routes (read/write .holyship/flow.yml) ────────
+  if (hasGitHubApp) {
+    app.route(
+      "/api",
+      createFlowEditorRoutes({
+        getGithubToken: async () => {
+          const installations = await installationRepo.listByTenant(tenantId);
+          if (installations.length === 0) return null;
+          const { token } = await getInstallationAccessToken(
+            config.GITHUB_APP_ID as string,
+            config.GITHUB_APP_PRIVATE_KEY as string,
+            installations[0].installationId,
+          );
+          return token;
+        },
+      }),
+    );
+    logger.info("Flow editor routes mounted");
   }
 
   // ─── 13. Crypto payments (BTCPay + EVM watchers) ────────────────────

--- a/src/routes/flow-editor.ts
+++ b/src/routes/flow-editor.ts
@@ -1,0 +1,65 @@
+/**
+ * Flow editor REST routes.
+ *
+ * Endpoints for reading and writing .holyship/flow.yml from a customer repo.
+ */
+
+import { Hono } from "hono";
+import { parse as parseYaml } from "yaml";
+
+export interface FlowEditorRouteDeps {
+  getGithubToken: () => Promise<string | null>;
+}
+
+export function createFlowEditorRoutes(deps: FlowEditorRouteDeps): Hono {
+  const app = new Hono();
+
+  // GET /repos/:owner/:repo/flow — read .holyship/flow.yml
+  app.get("/repos/:owner/:repo/flow", async (c) => {
+    const owner = c.req.param("owner");
+    const repo = c.req.param("repo");
+
+    const token = await deps.getGithubToken();
+    if (!token) {
+      return c.json({ error: "GitHub App not configured" }, 501);
+    }
+
+    const url = `https://api.github.com/repos/${owner}/${repo}/contents/.holyship/flow.yml`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+
+    if (res.status === 404) {
+      return c.json({ error: "No flow.yml found. Create .holyship/flow.yml to get started." }, 404);
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return c.json({ error: `GitHub API error: ${res.status}`, detail: text.slice(0, 500) }, 502);
+    }
+
+    const data = (await res.json()) as { content: string; sha: string; encoding: string };
+
+    if (data.encoding !== "base64") {
+      return c.json({ error: `Unexpected encoding: ${data.encoding}` }, 502);
+    }
+
+    const yaml = Buffer.from(data.content, "base64").toString("utf-8");
+
+    let flow: unknown;
+    try {
+      flow = parseYaml(yaml);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: "Invalid YAML in flow.yml", detail: message }, 422);
+    }
+
+    return c.json({ yaml, flow, sha: data.sha }, 200);
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary
- Reads `.holyship/flow.yml` from customer repo via GitHub Contents API
- Returns yaml string, parsed flow object, and blob SHA for optimistic concurrency
- 404 if no flow.yml exists; 422 if YAML is invalid

Closes #223

## Test plan
- [ ] GET with existing flow.yml returns 200 with yaml + flow + sha
- [ ] GET without flow.yml returns 404
- [ ] Invalid YAML returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)