### PR TITLE
feat: POST /repos/:owner/:repo/flow/apply — create PR with flow changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -473,6 +473,7 @@ async function main() {
     app.route(
       "/api",
       createFlowEditorRoutes({
+        workerToken: config.HOLYSHIP_WORKER_TOKEN,
         getGithubToken: async () => {
           const installations = await installationRepo.listByTenant(tenantId);
           if (installations.length === 0) return null;

--- a/src/routes/flow-editor.ts
+++ b/src/routes/flow-editor.ts
@@ -4,20 +4,48 @@
  * Endpoints for reading and writing .holyship/flow.yml from a customer repo.
  */
 
+import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { parse as parseYaml } from "yaml";
 
 export interface FlowEditorRouteDeps {
   getGithubToken: () => Promise<string | null>;
+  workerToken?: string;
+}
+
+function tokensMatch(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
 }
 
 export function createFlowEditorRoutes(deps: FlowEditorRouteDeps): Hono {
   const app = new Hono();
 
+  // Bearer token auth middleware
+  app.use("/*", async (c, next) => {
+    if (!deps.workerToken) return next();
+    const auth = c.req.header("Authorization");
+    if (!auth) return c.json({ error: "Missing Authorization header" }, 401);
+    const parts = auth.split(" ");
+    if (parts.length !== 2 || parts[0].toLowerCase() !== "bearer") {
+      return c.json({ error: "Invalid Authorization format" }, 401);
+    }
+    if (!tokensMatch(parts[1], deps.workerToken)) {
+      return c.json({ error: "Invalid token" }, 403);
+    }
+    return next();
+  });
+
   // GET /repos/:owner/:repo/flow — read .holyship/flow.yml
   app.get("/repos/:owner/:repo/flow", async (c) => {
     const owner = c.req.param("owner");
     const repo = c.req.param("repo");
+
+    if (!/^[\w.-]+$/.test(owner) || !/^[\w.-]+$/.test(repo)) {
+      return c.json({ error: "Invalid owner or repo name" }, 400);
+    }
 
     const token = await deps.getGithubToken();
     if (!token) {
@@ -65,6 +93,10 @@ export function createFlowEditorRoutes(deps: FlowEditorRouteDeps): Hono {
   app.post("/repos/:owner/:repo/flow/apply", async (c) => {
     const owner = c.req.param("owner");
     const repo = c.req.param("repo");
+
+    if (!/^[\w.-]+$/.test(owner) || !/^[\w.-]+$/.test(repo)) {
+      return c.json({ error: "Invalid owner or repo name" }, 400);
+    }
 
     const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
     const yaml = body.yaml as string | undefined;


### PR DESCRIPTION
## Summary
- POST endpoint creates a PR with updated .holyship/flow.yml
- Uses baseSha for optimistic concurrency (409 if file changed since read)
- Creates branch, updates file, creates PR via GitHub API

Closes #226

## Test plan
- [ ] POST with valid yaml + baseSha creates PR and returns prUrl/prNumber/branch
- [ ] POST with stale baseSha returns 409
- [ ] POST with empty yaml returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add POST /repos/:owner/:repo/flow/apply endpoint to create a PR updating .holyship/flow.yml
> - Adds a new Hono route module [`src/routes/flow-editor.ts`](https://github.com/wopr-network/holyship/pull/231/files#diff-cf5e56a6236e6feef3353c1c45d570e5fcccf64513400e0f2ef675e11b1c764c) with two endpoints: `GET /repos/:owner/:repo/flow` to fetch and parse `.holyship/flow.yml`, and `POST /repos/:owner/:repo/flow/apply` to create a PR updating it.
> - The apply endpoint fetches the repo's default branch, creates a new branch, updates the file using `baseSha` for optimistic concurrency, and opens a pull request; responds with PR URL, number, and branch name.
> - Routes are mounted under `/api` in [`src/index.ts`](https://github.com/wopr-network/holyship/pull/231/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) when a GitHub App is configured, and protected by optional Bearer token auth using constant-time comparison.
> - GitHub installation access tokens are now cached and reused when valid across the worker pool, ShipIt `fetchIssue`, and the new flow editor routes, refreshing and persisting via `installationRepo.updateToken` on expiry.
> - Risk: the 409 conflict path on file update (stale `baseSha`) surfaces directly to callers; clients must handle this case explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe8c15a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->