### PR TITLE
fix: /tmp/fleet permissions for meter WAL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY --chown=holyship:holyship --from=deps /app/node_modules ./node_modules
 COPY --chown=holyship:holyship --from=build /app/dist ./dist
 COPY --chown=holyship:holyship drizzle/ ./drizzle/
 COPY --chown=holyship:holyship package.json ./
-RUN mkdir -p gates
+RUN mkdir -p gates /tmp/fleet && chown holyship:holyship /tmp/fleet
 
 USER holyship
 


### PR DESCRIPTION
One-liner. Closes #241.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `/tmp/fleet` permissions in container for meter WAL writes
> The [Dockerfile](https://github.com/wopr-network/holyship/pull/242/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557) runtime stage now creates `/tmp/fleet` and sets its ownership to `holyship:holyship`, alongside the existing `gates` directory. This allows processes running as the `holyship` user to write the meter write-ahead log to `/tmp/fleet` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9eab82f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated container runtime environment to initialize and configure a system directory with proper ownership permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->