### PR TITLE
deps: bump platform-core to 1.67.1, remove dead oracle code

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@scure/bip39": "^2.0.1",
     "@sentry/node": "^9.27.0",
     "@trpc/server": "^11.13.4",
-    "@wopr-network/platform-core": "^1.63.0",
+    "@wopr-network/platform-core": "^1.67.1",
     "dockerode": "^4.0.9",
     "drizzle-orm": "^0.45.1",
     "handlebars": "^4.7.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^11.13.4
         version: 11.13.4(typescript@5.9.3)
       '@wopr-network/platform-core':
-        specifier: ^1.63.0
-        version: 1.63.0(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)
+        specifier: ^1.67.1
+        version: 1.67.1(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)
       dockerode:
         specifier: ^4.0.9
         version: 4.0.9
@@ -1578,8 +1578,14 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
-  '@wopr-network/platform-core@1.63.0':
-    resolution: {integrity: sha512-DBueTtdytB70mE72L6EHR9KmQJCAVLAg36UyZpWLQallrFNOE5goNhapWnxt9EoaZQE2Fw2WnE+pqAhCzPC9rQ==}
+  '@wopr-network/crypto-plugins@1.0.1':
+    resolution: {integrity: sha512-fTVlf3fZzEPBILDg9f+XE9iW6WCZXQsJCr9NGykxaoJT4rQGiDU8cZMhQiQacMzx4hbAgbdBDTv7l5eMomQU+Q==}
+    hasBin: true
+    peerDependencies:
+      '@wopr-network/platform-core': '*'
+
+  '@wopr-network/platform-core@1.67.1':
+    resolution: {integrity: sha512-kHhOhpzIe0vqE81tvPyzL1oconaIFjjPOTZvbLMY1F9mAqd8RVMCZaBfWfYdZN0XKC5AqGoZlYsYQQqkNwc9Cg==}
     peerDependencies:
       '@trpc/server': '>=11'
       better-auth: '>=1.5'
@@ -4420,7 +4426,21 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@wopr-network/platform-core@1.63.0(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)':
+  '@wopr-network/crypto-plugins@1.0.1(@wopr-network/platform-core@1.67.1(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6))(typescript@5.9.3)(zod@4.3.6)':
+    dependencies:
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/bip32': 2.0.1
+      '@scure/bip39': 2.0.1
+      '@wopr-network/platform-core': 1.67.1(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)
+      viem: 2.47.4(typescript@5.9.3)(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@wopr-network/platform-core@1.67.1(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)':
     dependencies:
       '@aws-sdk/client-ses': 3.1015.0
       '@hono/node-server': 1.19.11(hono@4.12.5)
@@ -4430,6 +4450,7 @@ snapshots:
       '@scure/bip32': 2.0.1
       '@scure/bip39': 2.0.1
       '@trpc/server': 11.13.4(typescript@5.9.3)
+      '@wopr-network/crypto-plugins': 1.0.1(@wopr-network/platform-core@1.67.1(@trpc/server@11.13.4(typescript@5.9.3))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6))(typescript@5.9.3)(zod@4.3.6)
       better-auth: 1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2))
       dockerode: 4.0.9
       drizzle-orm: 0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)

--- a/src/trpc/routers/billing.ts
+++ b/src/trpc/routers/billing.ts
@@ -11,14 +11,7 @@ import type {
   IPaymentMethodStore,
   IPaymentProcessor,
 } from "@wopr-network/platform-core/billing";
-import {
-  ChainlinkOracle,
-  type CryptoServiceClient,
-  createRpcCaller,
-  createUnifiedCheckout,
-  type IPriceOracle,
-  MIN_CHECKOUT_USD,
-} from "@wopr-network/platform-core/billing";
+import { type CryptoServiceClient, createUnifiedCheckout, MIN_CHECKOUT_USD } from "@wopr-network/platform-core/billing";
 import type { ILedger } from "@wopr-network/platform-core/credits";
 import {
   ALLOWED_SCHEDULE_INTERVALS,
@@ -156,7 +149,6 @@ export interface BillingRouterDeps {
   cryptoClient?: CryptoServiceClient;
   cryptoChargeRepo?: ICryptoChargeRepository;
   evmXpub?: string;
-  priceOracle?: IPriceOracle;
   paymentMethodStore?: IPaymentMethodStore;
   auditLogger?: AuditLogger;
   promotionEngine?: PromotionEngine;
@@ -173,23 +165,16 @@ export function setCryptoBillingDeps(
   cryptoClient: CryptoServiceClient,
   cryptoChargeRepo: ICryptoChargeRepository,
   evmXpub?: string,
-  evmRpcUrl?: string,
+  _evmRpcUrl?: string,
   paymentMethodStore?: IPaymentMethodStore,
 ): void {
-  let priceOracle: IPriceOracle | undefined;
-  if (evmRpcUrl) {
-    const rpcCall = createRpcCaller(evmRpcUrl);
-    priceOracle = new ChainlinkOracle({ rpcCall });
-  }
-
   if (!_deps) {
-    _deps = { cryptoClient, cryptoChargeRepo, evmXpub, priceOracle, paymentMethodStore } as BillingRouterDeps;
+    _deps = { cryptoClient, cryptoChargeRepo, evmXpub, paymentMethodStore } as BillingRouterDeps;
     return;
   }
   _deps.cryptoClient = cryptoClient;
   _deps.cryptoChargeRepo = cryptoChargeRepo;
   if (evmXpub) _deps.evmXpub = evmXpub;
-  if (priceOracle) _deps.priceOracle = priceOracle;
   if (paymentMethodStore) _deps.paymentMethodStore = paymentMethodStore;
 }
 
@@ -388,6 +373,11 @@ export const billingRouter = router({
         iconUrl: input.iconUrl ?? null,
         encodingParams: "",
         watcherType: "",
+        rpcHeaders: "{}",
+        oracleAssetId: null,
+        keyRingId: null,
+        encoding: null,
+        pluginId: null,
       });
       await auditLogger?.log({
         userId: ctx.user.id,


### PR DESCRIPTION
## Summary
- Bumps platform-core to 1.67.1 (crypto server extracted)
- Removes dead `ChainlinkOracle`/`createRpcCaller`/`IPriceOracle` imports (never read, leftover from local watcher era)
- Adds missing `PaymentMethodRecord` fields to upsert call

## Test plan
- [x] `npm run check` passes (biome + tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove oracle price discovery from billing and bump platform-core to 1.67.1
> - Removes `ChainlinkOracle`, `createRpcCaller`, and `IPriceOracle` imports from [billing.ts](https://github.com/wopr-network/holyship/pull/256/files#diff-2bdeb9388734985a0ab4c17336e201539c5566dccd4a19412e7d673c48e34f35); `setCryptoBillingDeps` no longer constructs or stores a price oracle and ignores the `evmRpcUrl` argument.
> - Adds default fields (`rpcHeaders`, `oracleAssetId`, `keyRingId`, `encoding`, `pluginId`) to the `paymentMethodStore.upsert` call to satisfy the updated `platform-core` API.
> - Bumps `@wopr-network/platform-core` from `^1.63.0` to `^1.67.1` in [package.json](https://github.com/wopr-network/holyship/pull/256/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31c92d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

## Summary by Sourcery

Bump platform-core dependency and simplify crypto billing by removing unused oracle integration and aligning payment method upserts with the updated API.

Enhancements:
- Remove unused price oracle support from crypto billing dependencies and setup.
- Populate additional payment method fields (headers, oracle asset, keyring, encoding, plugin) when upserting records to match the newer platform-core contract.

Build:
- Update @wopr-network/platform-core dependency from 1.63.0 to 1.67.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform core dependency to a newer version.
  * Streamlined billing configuration by removing unused price oracle integration and refactoring payment method storage to support additional configuration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->