### PR TITLE
ci: push :staging tag, Watchtower handles deploy

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,4 +29,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/wopr-network/holyship:latest
+          tags: |
+            ghcr.io/wopr-network/holyship:staging
+            ghcr.io/wopr-network/holyship:${{ github.sha }}


### PR DESCRIPTION
Watchtower model: main → :staging → promote → :latest

## Summary by Sourcery

CI:
- Adjust Docker GitHub Actions workflow to publish :staging and commit-SHA tags for the holyship image instead of the :latest tag.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Push `staging` and SHA tags in CI docker workflow for Watchtower deploys
> Updates [docker.yml](.github/workflows/docker.yml) to push two image tags (`staging` and the commit SHA) instead of `latest`. Watchtower uses the fixed `staging` tag to detect and deploy new images automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57749f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing to provide `staging` and commit-specific tags instead of a single `latest` tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->