### PR TITLE
feat: add staging VPS deploy to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,3 +32,46 @@ jobs:
           tags: |
             ghcr.io/wopr-network/holyship:staging
             ghcr.io/wopr-network/holyship:${{ github.sha }}
+
+  deploy-staging:
+    runs-on: [self-hosted, Linux, X64]
+    needs: build-push
+    steps:
+      - name: Deploy to staging VPS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: root
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            cd /opt/holyship
+            COMPOSE="docker compose -f docker-compose.yml -f docker-compose.staging.yml"
+            $COMPOSE stop staging-api 2>/dev/null || true
+            $COMPOSE pull staging-api
+            $COMPOSE up -d staging-postgres
+            sleep 3
+            $COMPOSE exec -T staging-postgres psql -U holyship -d holyship -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;" 2>/dev/null || true
+            docker compose exec -T postgres pg_dump -U holyship --no-owner --no-acl holyship | \
+              $COMPOSE exec -T staging-postgres psql -U holyship -d holyship -q
+            $COMPOSE up -d staging-api staging-ui
+            docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || docker compose restart caddy
+            echo "Staging deployed"
+
+      - name: Verify staging health
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: root
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            for i in $(seq 1 30); do
+              if docker exec holyship-staging-api-1 curl -sf http://localhost:3001/health >/dev/null 2>&1; then
+                echo "Staging API is healthy"
+                exit 0
+              fi
+              sleep 2
+            done
+            echo "Health check timed out"
+            docker logs holyship-staging-api-1 --tail 20
+            exit 1


### PR DESCRIPTION
## Summary
- Add `deploy-staging` job after `build-push` in Docker workflow
- SSH to staging VPS, copy prod DB into staging postgres, restart staging containers
- Health check verification after deploy

## Test plan
- [ ] CI passes
- [ ] Docker build-push succeeds
- [ ] deploy-staging job runs (requires `STAGING_HOST` + `PROD_SSH_KEY` secrets)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add staging VPS deploy job to Docker workflow
> - Adds a `deploy-staging` job to [docker.yml](.github/workflows/docker.yml) that runs after `build-push` completes, connecting to the staging VPS over SSH.
> - Resets the staging database by dropping and restoring the public schema, then seeds it by dumping from the production `postgres` service and restoring into `staging-postgres`.
> - Restarts `staging-api`, `staging-ui`, and caddy after the database reset.
> - Verifies deployment by polling `http://localhost:3001/health` inside the `holyship-staging-api-1` container up to 30 times, printing container logs and failing the workflow on timeout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba3b68f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with automated staging deployment and health verification checks to ensure deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->