### PR TITLE
feat(engine): gate artifact extraction

### DIFF
--- a/docs/plans/2026-04-01-gate-artifact-extraction.md
+++ b/docs/plans/2026-04-01-gate-artifact-extraction.md
@@ -1,0 +1,689 @@
+# Gate Artifact Extraction — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enhance existing gate primitive ops to return extracted artifacts alongside routing outcomes, and wire the engine to persist those artifacts on the entity before transitioning.
+
+**Architecture:** Three changes: (1) primitive ops return an optional `artifacts` record, (2) `resolveGate` propagates artifacts to the caller, (3) `_processSignalInner` persists gate artifacts before building the next invocation. The `GateEvalResult` and `GateOpResult` types gain an optional `artifacts` field. No new tables, no new concepts — just data flowing through existing pipes.
+
+**Tech Stack:** TypeScript, Vitest, existing gate evaluator + engine + primitive-ops modules.
+
+---
+
+### File Structure
+
+| File | Change | Responsibility |
+|------|--------|---------------|
+| `src/github/primitive-ops.ts` | Modify | Return extracted data (comment body, PR metadata) alongside outcome |
+| `src/engine/gate-evaluator.ts` | Modify | Pass artifacts through `GateEvalResult` |
+| `src/engine/engine.ts` | Modify | `resolveGate` returns artifacts; `_processSignalInner` persists them |
+| `src/flows/engineering.ts` | Modify | Add `outcomes` map to `spec-posted` gate |
+| `tests/github/primitive-ops.test.ts` | Create | Unit tests for artifact extraction in primitive ops |
+| `tests/engine/gate-artifact-extraction.test.ts` | Create | Integration test: gate passes → artifacts persisted on entity |
+
+---
+
+### Task 1: Enhance `GateOpResult` and `GateEvalResult` types with artifacts
+
+**Files:**
+- Modify: `src/github/primitive-ops.ts:7`
+- Modify: `src/engine/gate-evaluator.ts:11-19`
+
+- [ ] **Step 1: Add `artifacts` to `GateOpResult` type**
+
+In `src/github/primitive-ops.ts`, the `GateOpResult` type at line 7:
+
+```typescript
+// Before
+export type GateOpResult = { outcome: string; message?: string } & Record<string, unknown>;
+
+// After
+export type GateOpResult = { outcome: string; message?: string; artifacts?: Record<string, unknown> } & Record<string, unknown>;
+```
+
+- [ ] **Step 2: Add `artifacts` to `GateEvalResult` type**
+
+In `src/engine/gate-evaluator.ts`, the `GateEvalResult` interface at line 11:
+
+```typescript
+// Before
+export interface GateEvalResult {
+  passed: boolean;
+  timedOut: boolean;
+  output: string;
+  outcome?: string;
+  message?: string;
+}
+
+// After
+export interface GateEvalResult {
+  passed: boolean;
+  timedOut: boolean;
+  output: string;
+  outcome?: string;
+  message?: string;
+  /** Artifacts extracted by the gate op (e.g., comment body, PR metadata). */
+  artifacts?: Record<string, unknown>;
+}
+```
+
+- [ ] **Step 3: Propagate artifacts through primitive gate evaluation**
+
+In `src/engine/gate-evaluator.ts`, find the primitive gate evaluation block (inside `evaluateGate`, after the `primitiveOpHandler` call). The handler result needs to flow through to `GateEvalResult.artifacts`:
+
+Find the section that calls `primitiveOpHandler` and builds the result. After the handler returns, the `artifacts` field from the handler result should be passed through:
+
+```typescript
+// In the primitive gate type handler, after getting opResult from primitiveOpHandler:
+// Add this line after building the GateEvalResult:
+artifacts: opResult.artifacts,
+```
+
+The exact location is in the `if (gate.type === "primitive")` block. Find where `GateEvalResult` is constructed from the primitive op result and add `artifacts: opResult.artifacts` to the return.
+
+- [ ] **Step 4: Verify types compile**
+
+```bash
+cd ~/holyship && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: No type errors related to artifacts field.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/holyship && jj new && jj describe -m "feat(engine): add artifacts field to GateEvalResult and GateOpResult types"
+```
+
+---
+
+### Task 2: Enhance `checkCommentExists` to extract comment body
+
+**Files:**
+- Modify: `src/github/primitive-ops.ts:58-81`
+- Create: `tests/github/primitive-ops.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/github/primitive-ops.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { checkCommentExists } from "../../src/github/primitive-ops.js";
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("checkCommentExists", () => {
+  const ctx = { token: "test-token", owner: "wopr-network", repo: "test-repo" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 'exists' with extracted body when matching comment found", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { body: "Some unrelated comment" },
+        { body: "## Implementation Spec\n\nThis is the full spec text.\n\n### Details\nMore content here." },
+        { body: "Another comment" },
+      ],
+    });
+
+    const result = await checkCommentExists(ctx, {
+      issueNumber: 42,
+      pattern: "## Implementation Spec",
+    });
+
+    expect(result.outcome).toBe("exists");
+    expect(result.artifacts).toBeDefined();
+    expect(result.artifacts!.extractedBody).toContain("## Implementation Spec");
+    expect(result.artifacts!.extractedBody).toContain("More content here.");
+  });
+
+  it("returns 'not_found' with no artifacts when no match", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ body: "Unrelated comment" }],
+    });
+
+    const result = await checkCommentExists(ctx, {
+      issueNumber: 42,
+      pattern: "## Implementation Spec",
+    });
+
+    expect(result.outcome).toBe("not_found");
+    expect(result.artifacts).toBeUndefined();
+  });
+
+  it("returns last matching comment when multiple match", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { body: "## Implementation Spec\n\nOld version" },
+        { body: "## Implementation Spec\n\nNew version" },
+      ],
+    });
+
+    const result = await checkCommentExists(ctx, {
+      issueNumber: 42,
+      pattern: "## Implementation Spec",
+    });
+
+    expect(result.outcome).toBe("exists");
+    expect(result.artifacts!.extractedBody).toContain("New version");
+  });
+
+  it("returns error on API failure", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const result = await checkCommentExists(ctx, {
+      issueNumber: 42,
+      pattern: "## Implementation Spec",
+    });
+
+    expect(result.outcome).toBe("error");
+    expect(result.artifacts).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd ~/holyship && npx vitest run tests/github/primitive-ops.test.ts
+```
+
+Expected: FAIL — `extractedBody` not in result.
+
+- [ ] **Step 3: Implement — enhance `checkCommentExists`**
+
+In `src/github/primitive-ops.ts`, replace the `checkCommentExists` function (lines 58-81):
+
+```typescript
+/** Check if a comment matching a pattern exists on an issue. Extracts the last matching comment body. */
+export async function checkCommentExists(
+  ctx: GitHubGateContext,
+  params: { issueNumber: number; pattern: string },
+): Promise<GateOpResult> {
+  const res = await fetch(
+    `https://api.github.com/repos/${ctx.owner}/${ctx.repo}/issues/${params.issueNumber}/comments?per_page=100`,
+    {
+      headers: {
+        Authorization: `Bearer ${ctx.token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!res.ok) {
+    return { outcome: "error", message: `GitHub API error: ${res.status}` };
+  }
+  const comments = (await res.json()) as Array<{ body: string }>;
+  const regex = new RegExp(params.pattern);
+  // Use findLast so the most recent matching comment wins (spec may be re-posted)
+  const match = comments.filter((c) => regex.test(c.body)).at(-1);
+  return match
+    ? { outcome: "exists", message: "Matching comment found", artifacts: { extractedBody: match.body } }
+    : { outcome: "not_found", message: "No matching comment" };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd ~/holyship && npx vitest run tests/github/primitive-ops.test.ts
+```
+
+Expected: PASS — all 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/holyship && jj new && jj describe -m "feat(gates): checkCommentExists extracts matching comment body as artifact"
+```
+
+---
+
+### Task 3: Enhance `checkPrStatus` to extract PR metadata
+
+**Files:**
+- Modify: `src/github/primitive-ops.ts:39-55`
+- Modify: `tests/github/primitive-ops.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Add to `tests/github/primitive-ops.test.ts`:
+
+```typescript
+import { checkPrStatus } from "../../src/github/primitive-ops.js";
+
+describe("checkPrStatus", () => {
+  const ctx = { token: "test-token", owner: "wopr-network", repo: "test-repo" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 'mergeable' with PR metadata artifacts", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        merged: false,
+        state: "open",
+        mergeable_state: "clean",
+        html_url: "https://github.com/wopr-network/test-repo/pull/7",
+        number: 7,
+        head: { sha: "abc123def456" },
+      }),
+    });
+
+    const result = await checkPrStatus(ctx, { pullNumber: 7 });
+
+    expect(result.outcome).toBe("mergeable");
+    expect(result.artifacts).toBeDefined();
+    expect(result.artifacts!.prUrl).toBe("https://github.com/wopr-network/test-repo/pull/7");
+    expect(result.artifacts!.prNumber).toBe(7);
+    expect(result.artifacts!.headSha).toBe("abc123def456");
+  });
+
+  it("returns 'merged' with artifacts", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        merged: true,
+        state: "closed",
+        mergeable_state: "unknown",
+        html_url: "https://github.com/wopr-network/test-repo/pull/7",
+        number: 7,
+        head: { sha: "abc123" },
+      }),
+    });
+
+    const result = await checkPrStatus(ctx, { pullNumber: 7 });
+
+    expect(result.outcome).toBe("merged");
+    expect(result.artifacts!.prUrl).toBe("https://github.com/wopr-network/test-repo/pull/7");
+  });
+
+  it("returns 'blocked' with artifacts and message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        merged: false,
+        state: "open",
+        mergeable_state: "blocked",
+        html_url: "https://github.com/wopr-network/test-repo/pull/7",
+        number: 7,
+        head: { sha: "abc123" },
+      }),
+    });
+
+    const result = await checkPrStatus(ctx, { pullNumber: 7 });
+
+    expect(result.outcome).toBe("blocked");
+    expect(result.artifacts!.headSha).toBe("abc123");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd ~/holyship && npx vitest run tests/github/primitive-ops.test.ts
+```
+
+Expected: FAIL — `artifacts` not in PR status result.
+
+- [ ] **Step 3: Implement — enhance `checkPrStatus`**
+
+In `src/github/primitive-ops.ts`, replace `checkPrStatus` (lines 39-55):
+
+```typescript
+/** Check PR merge status. Extracts PR metadata as artifacts. */
+export async function checkPrStatus(ctx: GitHubGateContext, params: { pullNumber: number }): Promise<GateOpResult> {
+  const res = await fetch(`https://api.github.com/repos/${ctx.owner}/${ctx.repo}/pulls/${params.pullNumber}`, {
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    return { outcome: "error", message: `GitHub API error: ${res.status}` };
+  }
+  const pr = (await res.json()) as {
+    merged: boolean;
+    state: string;
+    mergeable_state: string;
+    html_url: string;
+    number: number;
+    head: { sha: string };
+  };
+  const prArtifacts = { prUrl: pr.html_url, prNumber: pr.number, headSha: pr.head.sha };
+  if (pr.merged) return { outcome: "merged", artifacts: prArtifacts };
+  if (pr.state === "closed") return { outcome: "closed", artifacts: prArtifacts };
+  if (pr.mergeable_state === "clean") return { outcome: "mergeable", artifacts: prArtifacts };
+  return { outcome: "blocked", message: `PR state: ${pr.mergeable_state}`, artifacts: prArtifacts };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd ~/holyship && npx vitest run tests/github/primitive-ops.test.ts
+```
+
+Expected: PASS — all tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/holyship && jj new && jj describe -m "feat(gates): checkPrStatus extracts PR metadata (url, number, headSha) as artifacts"
+```
+
+---
+
+### Task 4: Wire artifact propagation through engine `resolveGate`
+
+**Files:**
+- Modify: `src/engine/engine.ts:460-596`
+
+- [ ] **Step 1: Add `artifacts` to `resolveGate` return types**
+
+In `src/engine/engine.ts`, modify the `resolveGate` return type (lines 465-476). Add `artifacts?` to both `proceed` and `redirect` variants:
+
+```typescript
+  private async resolveGate(
+    gateId: string,
+    entity: Entity,
+    flow: Flow,
+    txRepos?: TransactionRepos | null,
+  ): Promise<
+    | { kind: "proceed"; gatesPassed: string[]; artifacts?: Record<string, unknown> }
+    | { kind: "redirect"; toState: string; trigger: string; gatesPassed: string[]; artifacts?: Record<string, unknown> }
+    | {
+        kind: "block";
+        gateTimedOut: boolean;
+        gateOutput: string;
+        gateName: string;
+        failurePrompt?: string;
+        timeoutPrompt?: string;
+        gatesPassed: string[];
+      }
+  > {
+```
+
+- [ ] **Step 2: Pass artifacts through in the `proceed` return**
+
+Find the proceed return at line 551:
+
+```typescript
+// Before
+return { kind: "proceed", gatesPassed: [gate.name] };
+
+// After
+return { kind: "proceed", gatesPassed: [gate.name], artifacts: gateResult.artifacts };
+```
+
+- [ ] **Step 3: Pass artifacts through in the `redirect` return**
+
+Find the redirect return at lines 535-540:
+
+```typescript
+// Before
+return {
+  kind: "redirect",
+  toState: namedOutcome.toState,
+  trigger: `gate:${gate.name}:${outcomeLabel}`,
+  gatesPassed: [gate.name],
+};
+
+// After
+return {
+  kind: "redirect",
+  toState: namedOutcome.toState,
+  trigger: `gate:${gate.name}:${outcomeLabel}`,
+  gatesPassed: [gate.name],
+  artifacts: gateResult.artifacts,
+};
+```
+
+- [ ] **Step 4: Persist gate artifacts in `_processSignalInner`**
+
+In `_processSignalInner` (around line 232), after the gate routing resolves and before the state transition, persist any gate artifacts. Find the section after:
+```typescript
+const routing = transition.gateId
+  ? await this.resolveGate(transition.gateId, entity, flow, txRepos)
+  : { kind: "proceed" as const, gatesPassed: [] as string[] };
+```
+
+Add artifact persistence right after the routing block, before `toState` resolution:
+
+```typescript
+// Persist gate-extracted artifacts (e.g., spec body, PR metadata)
+if (routing.kind !== "block" && routing.artifacts && Object.keys(routing.artifacts).length > 0) {
+  await entityRepo.updateArtifacts(entityId, routing.artifacts);
+  // Refresh entity so subsequent template rendering sees the new artifacts
+  const refreshed = await entityRepo.get(entityId);
+  if (refreshed) entity = refreshed;
+}
+```
+
+- [ ] **Step 5: Verify types compile**
+
+```bash
+cd ~/holyship && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: No errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/holyship && jj new && jj describe -m "feat(engine): resolveGate propagates and persists gate-extracted artifacts"
+```
+
+---
+
+### Task 5: Add `outcomes` map to `spec-posted` gate and wire `architectSpec` artifact
+
+**Files:**
+- Modify: `src/flows/engineering.ts:241-252`
+- Modify: `src/github/primitive-ops.ts` (rename extracted artifact key)
+
+- [ ] **Step 1: Add outcomes to spec-posted gate definition**
+
+In `src/flows/engineering.ts`, update the `spec-posted` gate (line 241):
+
+```typescript
+  {
+    name: "spec-posted",
+    type: "primitive",
+    primitiveOp: "issue_tracker.comment_exists",
+    primitiveParams: {
+      issueNumber: "{{entity.artifacts.issueNumber}}",
+      pattern: "## Implementation Spec",
+    },
+    timeoutMs: 120_000,
+    failurePrompt:
+      "The spec gate checked for a comment starting with '## Implementation Spec' on issue #{{entity.artifacts.issueNumber}} and did not find one. Post the spec as a comment on the issue. The comment MUST start with the exact heading '## Implementation Spec'.",
+    timeoutPrompt: "The spec gate timed out after 2 minutes. The GitHub API may be slow. Try posting the spec again.",
+    outcomes: {
+      exists: { proceed: true },
+      not_found: { proceed: false },
+    },
+  },
+```
+
+- [ ] **Step 2: Map `extractedBody` to `architectSpec` in the primitiveOpHandler**
+
+The `checkCommentExists` returns `{ artifacts: { extractedBody: "..." } }`. The coder's prompt template references `{{entity.artifacts.architectSpec}}`. We need to map the key.
+
+In `src/index.ts`, in the `primitiveOpHandler` switch case for `issue_tracker.comment_exists` (around line 340), remap the artifact key after calling `checkCommentExists`:
+
+```typescript
+        case "issue_tracker.comment_exists": {
+          const result = await checkCommentExists(ctx, {
+            issueNumber: Number(params.issueNumber),
+            pattern: params.pattern as string,
+          });
+          // Map extractedBody to the artifact key specified in gate params (default: extractedBody)
+          if (result.artifacts?.extractedBody && params.artifactKey) {
+            result.artifacts[params.artifactKey as string] = result.artifacts.extractedBody;
+            delete result.artifacts.extractedBody;
+          }
+          return result;
+        }
+```
+
+- [ ] **Step 3: Add `artifactKey` to the spec-posted gate params**
+
+In `src/flows/engineering.ts`, add `artifactKey` to the spec-posted gate's `primitiveParams`:
+
+```typescript
+    primitiveParams: {
+      issueNumber: "{{entity.artifacts.issueNumber}}",
+      pattern: "## Implementation Spec",
+      artifactKey: "architectSpec",
+    },
+```
+
+- [ ] **Step 4: Update existing engineering flow test**
+
+In `tests/flows/engineering-flow.test.ts`, update the gate count test if needed and add a test for the new outcomes map:
+
+```typescript
+  it("spec-posted gate has outcomes map", () => {
+    const specGate = GATES.find((g) => g.name === "spec-posted");
+    expect(specGate?.outcomes).toEqual({
+      exists: { proceed: true },
+      not_found: { proceed: false },
+    });
+  });
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd ~/holyship && npx vitest run tests/flows/engineering-flow.test.ts tests/github/primitive-ops.test.ts
+```
+
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/holyship && jj new && jj describe -m "feat(flows): spec-posted gate extracts comment body as architectSpec artifact"
+```
+
+---
+
+### Task 6: Integration test — gate artifact flows through to entity
+
+**Files:**
+- Create: `tests/engine/gate-artifact-extraction.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/engine/gate-artifact-extraction.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import type { GateEvalResult } from "../../src/engine/gate-evaluator.js";
+
+/**
+ * Unit test: verify that when a gate evaluation returns artifacts,
+ * they are present in the GateEvalResult and can be propagated.
+ *
+ * Full integration (engine + DB) is tested in the existing
+ * gate-evaluator.test.ts suite. This focuses on the artifact contract.
+ */
+describe("Gate artifact extraction contract", () => {
+  it("GateEvalResult can carry artifacts", () => {
+    const result: GateEvalResult = {
+      passed: true,
+      timedOut: false,
+      output: "Matching comment found",
+      outcome: "exists",
+      artifacts: { architectSpec: "## Implementation Spec\n\nThe full spec." },
+    };
+
+    expect(result.artifacts).toBeDefined();
+    expect(result.artifacts!.architectSpec).toContain("## Implementation Spec");
+  });
+
+  it("GateEvalResult without artifacts is backward-compatible", () => {
+    const result: GateEvalResult = {
+      passed: true,
+      timedOut: false,
+      output: "All checks passed",
+      outcome: "passed",
+    };
+
+    expect(result.artifacts).toBeUndefined();
+  });
+
+  it("PR metadata artifacts have expected shape", () => {
+    const result: GateEvalResult = {
+      passed: true,
+      timedOut: false,
+      output: "PR is mergeable",
+      outcome: "mergeable",
+      artifacts: {
+        prUrl: "https://github.com/wopr-network/holyship/pull/42",
+        prNumber: 42,
+        headSha: "abc123def456",
+      },
+    };
+
+    expect(result.artifacts!.prUrl).toMatch(/^https:\/\/github\.com\//);
+    expect(result.artifacts!.prNumber).toBe(42);
+    expect(typeof result.artifacts!.headSha).toBe("string");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cd ~/holyship && npx vitest run tests/engine/gate-artifact-extraction.test.ts
+```
+
+Expected: PASS — all 3 tests green.
+
+- [ ] **Step 3: Run full test suite to verify no regressions**
+
+```bash
+cd ~/holyship && npx vitest run 2>&1 | tail -10
+```
+
+Expected: All existing tests pass + new tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/holyship && jj new && jj describe -m "test(engine): add gate artifact extraction contract tests"
+```
+
+---
+
+### Task 7: Run check and push
+
+**Files:** None — verification only.
+
+- [ ] **Step 1: Run check**
+
+```bash
+cd ~/holyship && npm run check 2>&1 | tail -10
+```
+
+Expected: Clean.
+
+- [ ] **Step 2: Push**
+
+```bash
+cd ~/holyship && jj git push
+```

--- a/docs/plans/2026-04-01-phase2-new-primitive-ops.md
+++ b/docs/plans/2026-04-01-phase2-new-primitive-ops.md
@@ -1,0 +1,23 @@
+# Phase 2: New Primitive Ops — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 4 new GitHub primitive gate ops so all engineering flow transitions can be gate-driven instead of relying on agent signal strings.
+
+**Architecture:** New functions in `primitive-ops.ts`, new cases in the `primitiveOpHandler` switch in `index.ts`, new gate definitions in `engineering.ts`. Same pattern as Phase 1.
+
+**Tech Stack:** TypeScript, Vitest, GitHub REST API
+
+---
+
+### Task 1: `vcs.pr_for_branch` — detect PR creation
+
+### Task 2: `vcs.pr_review_status` — detect clean vs issues
+
+### Task 3: `vcs.pr_head_changed` — detect fixes pushed
+
+### Task 4: `vcs.files_changed_since` — detect docs committed
+
+### Task 5: Wire all 4 ops into primitiveOpHandler + add gate definitions
+
+### Task 6: Tests + check + push

--- a/docs/specs/2026-04-01-gate-driven-signals-design.md
+++ b/docs/specs/2026-04-01-gate-driven-signals-design.md
@@ -1,0 +1,256 @@
+# Gate-Driven Signals — Design Spec
+
+**Problem:** The engineering flow depends on agents outputting exact signal strings (`spec_ready`, `pr_created`, `clean`, etc.) and structured artifact JSON. LLM agents are unreliable at outputting structured data consistently. When they don't, entities get stuck.
+
+**Solution:** Invert the signal model. Instead of "agent decides the signal, engine executes it," use "agent says done, engine evaluates gates to determine what happened." Gates check external systems (GitHub) for evidence of completed work, extract artifacts, and determine the transition. Agent output format becomes irrelevant for the 80% of signals that correspond to externally observable outcomes.
+
+**Goal:** Zero dependence on agent output format for artifact extraction. Fuzzy fallback for agent-judgment signals.
+
+## Architecture
+
+### Current Model (Fragile)
+```
+Agent outputs exact signal string → Engine matches transition → Gate evaluates → State changes
+Agent outputs structured artifacts → Engine stores them → Next state prompt template uses them
+```
+
+### New Model (Robust)
+```
+Agent exits (any output) → Engine evaluates ALL outgoing gates → Gate results determine transition + extract artifacts → State changes
+```
+
+### Signal Categories
+
+**Category A — Externally Observable (gate-driven, ~80% of transitions):**
+
+| Current Signal | Gate Replacement | What Gate Checks |
+|---|---|---|
+| `spec_ready` | `spec-posted` | GitHub issue has comment matching "## Implementation Spec" |
+| `pr_created` | `pr-exists` | GitHub PR exists from entity's branch pattern |
+| `clean` | `review-approved` | PR has no unresolved review comments, all bots resolved |
+| `ci_failed` | `ci-green` (already exists) | CI check runs status |
+| `fixes_pushed` | `pr-updated` | PR head SHA changed since last review |
+| `docs_ready` | `docs-committed` | PR has commits touching docs/ or README since last state |
+| `merged` | `pr-mergeable` (already exists) | PR merged status |
+| `blocked` | `pr-mergeable` (already exists) | PR blocked/conflict status |
+
+**Category B — Agent Judgment (fuzzy signal matching, ~20%):**
+
+| Signal | Why Gate Can't Determine It |
+|---|---|
+| `cant_resolve` | Agent's assessment that the findings contradict the spec — subjective |
+| `cant_document` | Agent's assessment that docs can't be written — subjective |
+| `closed` | Already handled by `pr-mergeable` gate outcome |
+
+### Execution Flow
+
+1. Agent receives prompt, does work, exits (outputs whatever it wants)
+2. WorkerPool receives the SSE result
+3. Instead of extracting a signal string, WorkerPool calls `engine.evaluateAndTransition(entityId)`
+4. Engine evaluates all outgoing gates from the entity's current state
+5. First gate that passes determines the transition AND extracts artifacts
+6. If no gate passes, check for Category B fuzzy signal in agent output
+7. If nothing matches, entity stays in current state — logged, retried on next claim
+
+### Gate Artifact Extraction
+
+Gates return both routing outcomes AND extracted data:
+
+```typescript
+// Current
+{ outcome: "exists", message: "Matching comment found" }
+
+// New
+{ outcome: "exists", message: "Matching comment found", artifacts: { architectSpec: "<full comment body>" } }
+```
+
+Gate evaluator persists `artifacts` to entity when gate passes.
+
+#### Per-Gate Extraction Contracts
+
+**spec-posted:**
+```typescript
+// checkCommentExists enhanced
+const match = comments.find((c) => regex.test(c.body));
+return match
+  ? { outcome: "exists", artifacts: { architectSpec: match.body } }
+  : { outcome: "not_found" };
+```
+
+**pr-exists (NEW):**
+```typescript
+// New primitive op: vcs.pr_for_branch
+// Checks if a PR exists from a branch matching a pattern
+// Returns: { outcome: "exists", artifacts: { prUrl, prNumber, headSha, headBranch } }
+//          { outcome: "not_found" }
+```
+
+**pr-updated (NEW):**
+```typescript
+// New primitive op: vcs.pr_head_changed
+// Checks if PR head SHA differs from entity.artifacts.lastReviewedSha
+// Returns: { outcome: "changed", artifacts: { headSha: newSha } }
+//          { outcome: "unchanged" }
+```
+
+**review-approved (NEW):**
+```typescript
+// New primitive op: vcs.pr_review_status
+// Checks unresolved review comments, bot statuses
+// Returns: { outcome: "clean" }
+//          { outcome: "has_issues", artifacts: { reviewFindings: extractedFindings } }
+```
+
+**docs-committed (NEW):**
+```typescript
+// New primitive op: vcs.files_changed_since
+// Checks if docs files changed in PR since a given SHA
+// Returns: { outcome: "changed" }
+//          { outcome: "unchanged" }
+```
+
+### Fuzzy Signal Matching (Category B)
+
+For agent-judgment signals, use a simple keyword classifier on the agent's final text output:
+
+```typescript
+function classifyAgentOutput(text: string): string | null {
+  const lower = text.toLowerCase();
+  
+  // cant_resolve patterns
+  if (/can'?t\s+resolve|cannot\s+resolve|unable\s+to\s+(fix|resolve)|contradicts?\s+(the\s+)?spec/i.test(lower)) {
+    return "cant_resolve";
+  }
+  
+  // cant_document patterns  
+  if (/can'?t\s+document|cannot\s+document|unable\s+to\s+(write|create)\s+doc/i.test(lower)) {
+    return "cant_document";
+  }
+  
+  return null; // No judgment signal detected
+}
+```
+
+No LLM call needed — regex is sufficient for these cases. The patterns are distinctive enough.
+
+### Engine Changes
+
+#### New method: `evaluateAndTransition`
+
+```typescript
+async evaluateAndTransition(
+  entityId: string,
+  agentOutput?: string,  // raw agent text for fuzzy matching
+  agentArtifacts?: Record<string, unknown>,  // any structured artifacts agent DID provide
+): Promise<ProcessSignalResult> {
+  const entity = await this.entityRepo.get(entityId);
+  const flow = await this.flowRepo.getAtVersion(entity.flowId, entity.flowVersion);
+  
+  // Get all outgoing transitions from current state
+  const outgoing = flow.transitions.filter(t => t.fromState === entity.state);
+  
+  // Evaluate gates on each transition (priority-sorted)
+  for (const transition of outgoing.sort((a, b) => b.priority - a.priority)) {
+    if (!transition.gateId) continue;
+    
+    const gateResult = await this.resolveGate(transition.gateId, entity, flow);
+    if (gateResult.kind === "proceed") {
+      // Gate passed — extract artifacts and transition
+      if (gateResult.artifacts) {
+        await this.entityRepo.updateArtifacts(entityId, gateResult.artifacts);
+      }
+      return this.processSignal(entityId, transition.trigger, agentArtifacts);
+    }
+    if (gateResult.kind === "redirect") {
+      // Gate redirected (e.g., CI failed → fix)
+      if (gateResult.artifacts) {
+        await this.entityRepo.updateArtifacts(entityId, gateResult.artifacts);
+      }
+      return this.processSignal(entityId, gateResult.trigger, agentArtifacts);
+    }
+  }
+  
+  // No gate passed — try fuzzy signal matching
+  if (agentOutput) {
+    const fuzzySignal = classifyAgentOutput(agentOutput);
+    if (fuzzySignal) {
+      return this.processSignal(entityId, fuzzySignal, agentArtifacts);
+    }
+  }
+  
+  // Nothing matched — entity stays in current state
+  return { gated: true, gatesPassed: [], terminal: false };
+}
+```
+
+#### Gate evaluator: persist extracted artifacts
+
+When a gate result includes `artifacts`, the gate evaluator returns them to the engine for persistence:
+
+```typescript
+// In resolveGate return type, add:
+artifacts?: Record<string, unknown>;
+```
+
+#### WorkerPool change
+
+```typescript
+// Current (worker-pool.ts:367-371)
+if (signal) {
+  const signalResult = await this.engine.processSignal(entityId, signal, resultArtifacts);
+}
+
+// New
+const signalResult = await this.engine.evaluateAndTransition(
+  entityId,
+  body,  // raw SSE body for fuzzy matching
+  resultArtifacts,  // any structured artifacts from agent
+);
+```
+
+### Flow Definition Changes
+
+All transitions need gates. New gates added for transitions that currently rely on agent signals:
+
+```typescript
+// New gates
+{ name: "pr-exists", type: "primitive", primitiveOp: "vcs.pr_for_branch",
+  primitiveParams: { branchPattern: "agent/{{entity.id}}/*" },
+  outcomes: { exists: { proceed: true }, not_found: { proceed: false } } },
+
+{ name: "review-approved", type: "primitive", primitiveOp: "vcs.pr_review_status",
+  primitiveParams: { pullNumber: "{{entity.artifacts.prNumber}}" },
+  outcomes: { clean: { proceed: true }, has_issues: { toState: "fix" } } },
+
+{ name: "pr-updated", type: "primitive", primitiveOp: "vcs.pr_head_changed",
+  primitiveParams: { pullNumber: "{{entity.artifacts.prNumber}}", lastSha: "{{entity.artifacts.lastReviewedSha}}" },
+  outcomes: { changed: { proceed: true }, unchanged: { proceed: false } } },
+
+{ name: "docs-committed", type: "primitive", primitiveOp: "vcs.files_changed_since",
+  primitiveParams: { pullNumber: "{{entity.artifacts.prNumber}}", paths: "docs/,README*,*.md", sinceSha: "{{entity.artifacts.docsBaseSha}}" },
+  outcomes: { changed: { proceed: true }, unchanged: { proceed: false } } },
+```
+
+Update `spec-posted` gate to include outcomes:
+```typescript
+{ name: "spec-posted", ..., outcomes: { exists: { proceed: true }, not_found: { proceed: false } } }
+```
+
+### Migration Path
+
+1. **Phase 1**: Enhance existing gates to return artifacts (spec-posted, ci-green, pr-mergeable). Minimal changes.
+2. **Phase 2**: Add new primitive ops (pr_for_branch, pr_review_status, pr_head_changed, files_changed_since).
+3. **Phase 3**: Add `evaluateAndTransition` to engine. Wire WorkerPool to use it.
+4. **Phase 4**: Add fuzzy signal classifier for Category B signals.
+5. **Phase 5**: Remove exact-signal-match requirements from prompt templates. Simplify to "do the work, we'll check."
+
+Each phase independently improves the system. Phase 1 alone solves the architectSpec handoff.
+
+### What Doesn't Change
+
+- Flow definition structure (states, transitions, gates)
+- IFlowEngine interface (claim/report still works for external callers)
+- WorkerPool lifecycle (provision → dispatch → teardown)
+- Gate evaluation logic (just returns more data)
+- Prompt templates (still use `{{entity.artifacts.X}}` — just populated by gates now)
+- Entity/invocation data model

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@scure/bip39": "^2.0.1",
     "@sentry/node": "^9.27.0",
     "@trpc/server": "^11.13.4",
-    "@wopr-network/platform-core": "^1.71.0",
+    "@wopr-network/platform-core": "^1.74.0",
     "dockerode": "^4.0.9",
     "drizzle-orm": "^0.45.1",
     "handlebars": "^4.7.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^11.13.4
         version: 11.13.4(typescript@5.9.3)
       '@wopr-network/platform-core':
-        specifier: ^1.71.0
-        version: 1.71.0(@aws-sdk/client-ses@3.1015.0)(@trpc/server@11.13.4(typescript@5.9.3))(@wopr-network/platform-crypto-server@1.1.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(postgres@3.4.8)(typescript@5.9.3)(zod@4.3.6))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)
+        specifier: ^1.74.0
+        version: 1.74.0(@aws-sdk/client-ses@3.1015.0)(@trpc/server@11.13.4(typescript@5.9.3))(@wopr-network/platform-crypto-server@1.1.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(postgres@3.4.8)(typescript@5.9.3)(zod@4.3.6))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)
       dockerode:
         specifier: ^4.0.9
         version: 4.0.9
@@ -125,40 +125,40 @@ packages:
     resolution: {integrity: sha512-Gp+1l91bAQUYGHCPatXpU0LmWdkB5yCJUnlMkp7yK7fNUJ0oB4wzZe6675F2xBFM8wGqNcbdd2hxYr7BqIRwGw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.24':
-    resolution: {integrity: sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==}
+  '@aws-sdk/core@3.973.25':
+    resolution: {integrity: sha512-TNrx7eq6nKNOO62HWPqoBqPLXEkW6nLZQGwjL6lq1jZtigWYbK1NbCnT7mKDzbLMHZfuOECUt3n6CzxjUW9HWQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.22':
-    resolution: {integrity: sha512-cXp0VTDWT76p3hyK5D51yIKEfpf6/zsUvMfaB8CkyqadJxMQ8SbEeVroregmDlZbtG31wkj9ei0WnftmieggLg==}
+  '@aws-sdk/credential-provider-env@3.972.23':
+    resolution: {integrity: sha512-EamaclJcCEaPHp6wiVknNMM2RlsPMjAHSsYSFLNENBM8Wz92QPc6cOn3dif6vPDQt0Oo4IEghDy3NMDCzY/IvA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.24':
-    resolution: {integrity: sha512-h694K7+tRuepSRJr09wTvQfaEnjzsKZ5s7fbESrVds02GT/QzViJ94/HCNwM7bUfFxqpPXHxulZfL6Cou0dwPg==}
+  '@aws-sdk/credential-provider-http@3.972.25':
+    resolution: {integrity: sha512-qPymamdPcLp6ugoVocG1y5r69ScNiRzb0hogX25/ij+Wz7c7WnsgjLTaz7+eB5BfRxeyUwuw5hgULMuwOGOpcw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.24':
-    resolution: {integrity: sha512-O46fFmv0RDFWiWEA9/e6oW92BnsyAXuEgTTasxHligjn2RCr9L/DK773m/NoFaL3ZdNAUz8WxgxunleMnHAkeQ==}
+  '@aws-sdk/credential-provider-ini@3.972.26':
+    resolution: {integrity: sha512-xKxEAMuP6GYx2y5GET+d3aGEroax3AgGfwBE65EQAUe090lzyJ/RzxPX9s8v7Z6qAk0XwfQl+LrmH05X7YvTeg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.24':
-    resolution: {integrity: sha512-sIk8oa6AzDoUhxsR11svZESqvzGuXesw62Rl2oW6wguZx8i9cdGCvkFg+h5K7iucUZP8wyWibUbJMc+J66cu5g==}
+  '@aws-sdk/credential-provider-login@3.972.26':
+    resolution: {integrity: sha512-EFcM8RM3TUxnZOfMJo++3PnyxFu1fL/huzmn3Vh+8IWRgqZawUD3cRwwOr+/4bE9DpyHaLOWFAjY0lfK5X9ZkQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.25':
-    resolution: {integrity: sha512-m7dR0Dsva2P+VUpL+VkC0WwiDby5pgmWXkRVDB5rlwv0jXJrQJf7YMtCoM8Wjk0H9jPeCYOxOXXcIgp/qp5Alg==}
+  '@aws-sdk/credential-provider-node@3.972.27':
+    resolution: {integrity: sha512-jXpxSolfFnPVj6GCTtx3xIdWNoDR7hYC/0SbetGZxOC9UnNmipHeX1k6spVstf7eWJrMhXNQEgXC0pD1r5tXIg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.22':
-    resolution: {integrity: sha512-Os32s8/4gTZjBk5BtoS/cuTILaj+K72d0dVG7TCJX/fC4598cxwLDmf1AEHEpER5oL3K//yETjvFaz0V8oO5Xw==}
+  '@aws-sdk/credential-provider-process@3.972.23':
+    resolution: {integrity: sha512-IL/TFW59++b7MpHserjUblGrdP5UXy5Ekqqx1XQkERXBFJcZr74I7VaSrQT5dxdRMU16xGK4L0RQ5fQG1pMgnA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.24':
-    resolution: {integrity: sha512-PaFv7snEfypU2yXkpvfyWgddEbDLtgVe51wdZlinhc2doubBjUzJZZpgwuF2Jenl1FBydMhNpMjD6SBUM3qdSA==}
+  '@aws-sdk/credential-provider-sso@3.972.26':
+    resolution: {integrity: sha512-c6ghvRb6gTlMznWhGxn/bpVCcp0HRaz4DobGVD9kI4vwHq186nU2xN/S7QGkm0lo0H2jQU8+dgpUFLxfTcwCOg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.24':
-    resolution: {integrity: sha512-J6H4R1nvr3uBTqD/EeIPAskrBtET4WFfNhpFySr2xW7bVZOXpQfPjrLSIx65jcNjBmLXzWq8QFLdVoGxiGG/SA==}
+  '@aws-sdk/credential-provider-web-identity@3.972.26':
+    resolution: {integrity: sha512-cXcS3+XD3iwhoXkM44AmxjmbcKueoLCINr1e+IceMmCySda5ysNIfiGBGe9qn5EMiQ9Jd7pP0AGFtcd6OV3Lvg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-host-header@3.972.8':
@@ -169,24 +169,24 @@ packages:
     resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-recursion-detection@3.972.8':
-    resolution: {integrity: sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==}
+  '@aws-sdk/middleware-recursion-detection@3.972.9':
+    resolution: {integrity: sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.25':
-    resolution: {integrity: sha512-QxiMPofvOt8SwSynTOmuZfvvPM1S9QfkESBxB22NMHTRXCJhR5BygLl8IXfC4jELiisQgwsgUby21GtXfX3f/g==}
+  '@aws-sdk/middleware-user-agent@3.972.26':
+    resolution: {integrity: sha512-AilFIh4rI/2hKyyGN6XrB0yN96W2o7e7wyrPWCM6QjZM1mcC/pVkW3IWWRvuBWMpVP8Fg+rMpbzeLQ6dTM4gig==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.14':
-    resolution: {integrity: sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==}
+  '@aws-sdk/nested-clients@3.996.16':
+    resolution: {integrity: sha512-L7Qzoj/qQU1cL5GnYLQP5LbI+wlLCLoINvcykR3htKcQ4tzrPf2DOs72x933BM7oArYj1SKrkb2lGlsJHIic3g==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.9':
-    resolution: {integrity: sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==}
+  '@aws-sdk/region-config-resolver@3.972.10':
+    resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1015.0':
-    resolution: {integrity: sha512-3OSD4y110nisRhHzFOjoEeHU4GQL4KpzkX9PxzWaiZe0Yg2+thZKM0Pn9DjYwezH5JYfh/K++xK/SE0IHGrmCQ==}
+  '@aws-sdk/token-providers@3.1019.0':
+    resolution: {integrity: sha512-OF+2RfRmUKyjzrRWlDcyju3RBsuqcrYDQ8TwrJg8efcOotMzuZN4U9mpVTIdATpmEc4lWNZBMSjPzrGm6JPnAQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -204,8 +204,8 @@ packages:
   '@aws-sdk/util-user-agent-browser@3.972.8':
     resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
 
-  '@aws-sdk/util-user-agent-node@3.973.11':
-    resolution: {integrity: sha512-1qdXbXo2s5MMLpUvw00284LsbhtlQ4ul7Zzdn5n+7p4WVgCMLqhxImpHIrjSoc72E/fyc4Wq8dLtUld2Gsh+lA==}
+  '@aws-sdk/util-user-agent-node@3.973.12':
+    resolution: {integrity: sha512-8phW0TS8ntENJgDcFewYT/Q8dOmarpvSxEjATu2GUBAutiHr++oEGCiBUwxslCMNvwW2cAPZNT53S/ym8zm/gg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -213,8 +213,8 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.15':
-    resolution: {integrity: sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==}
+  '@aws-sdk/xml-builder@3.972.16':
+    resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -1584,8 +1584,8 @@ packages:
     peerDependencies:
       '@wopr-network/platform-crypto-server': '*'
 
-  '@wopr-network/platform-core@1.71.0':
-    resolution: {integrity: sha512-8n2xqokcwWvf3z8kBCV+aTXf8wS1IjA3iKn64aWaeTtNbfunN5ILOe6jPq4HPS2yRoHeF9tsjgaZYNGDVGPaxA==}
+  '@wopr-network/platform-core@1.74.0':
+    resolution: {integrity: sha512-CzYUVN82h7pTc/oaw/mMo2cF8ar0llREb51EHXjxlkVrBO/jna+rbtUrug23S2/J+ROas29/3p9R1OnI9HDMlQ==}
     peerDependencies:
       '@aws-sdk/client-ses': '>=3'
       '@trpc/server': '>=11'
@@ -2980,17 +2980,17 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/credential-provider-node': 3.972.25
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/credential-provider-node': 3.972.27
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.25
-      '@aws-sdk/region-config-resolver': 3.972.9
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.26
+      '@aws-sdk/region-config-resolver': 3.972.10
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.11
+      '@aws-sdk/util-user-agent-node': 3.973.12
       '@smithy/config-resolver': 4.4.13
       '@smithy/core': 3.23.12
       '@smithy/fetch-http-handler': 5.3.15
@@ -3021,10 +3021,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.973.24':
+  '@aws-sdk/core@3.973.25':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@aws-sdk/xml-builder': 3.972.15
+      '@aws-sdk/xml-builder': 3.972.16
       '@smithy/core': 3.23.12
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
@@ -3037,17 +3037,17 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.22':
+  '@aws-sdk/credential-provider-env@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.24':
+  '@aws-sdk/credential-provider-http@3.972.25':
     dependencies:
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/types': 3.973.6
       '@smithy/fetch-http-handler': 5.3.15
       '@smithy/node-http-handler': 4.5.0
@@ -3058,16 +3058,16 @@ snapshots:
       '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.24':
+  '@aws-sdk/credential-provider-ini@3.972.26':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/credential-provider-env': 3.972.22
-      '@aws-sdk/credential-provider-http': 3.972.24
-      '@aws-sdk/credential-provider-login': 3.972.24
-      '@aws-sdk/credential-provider-process': 3.972.22
-      '@aws-sdk/credential-provider-sso': 3.972.24
-      '@aws-sdk/credential-provider-web-identity': 3.972.24
-      '@aws-sdk/nested-clients': 3.996.14
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/credential-provider-env': 3.972.23
+      '@aws-sdk/credential-provider-http': 3.972.25
+      '@aws-sdk/credential-provider-login': 3.972.26
+      '@aws-sdk/credential-provider-process': 3.972.23
+      '@aws-sdk/credential-provider-sso': 3.972.26
+      '@aws-sdk/credential-provider-web-identity': 3.972.26
+      '@aws-sdk/nested-clients': 3.996.16
       '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
@@ -3077,10 +3077,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.24':
+  '@aws-sdk/credential-provider-login@3.972.26':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/nested-clients': 3.996.14
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.16
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/protocol-http': 5.3.12
@@ -3090,14 +3090,14 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.25':
+  '@aws-sdk/credential-provider-node@3.972.27':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.22
-      '@aws-sdk/credential-provider-http': 3.972.24
-      '@aws-sdk/credential-provider-ini': 3.972.24
-      '@aws-sdk/credential-provider-process': 3.972.22
-      '@aws-sdk/credential-provider-sso': 3.972.24
-      '@aws-sdk/credential-provider-web-identity': 3.972.24
+      '@aws-sdk/credential-provider-env': 3.972.23
+      '@aws-sdk/credential-provider-http': 3.972.25
+      '@aws-sdk/credential-provider-ini': 3.972.26
+      '@aws-sdk/credential-provider-process': 3.972.23
+      '@aws-sdk/credential-provider-sso': 3.972.26
+      '@aws-sdk/credential-provider-web-identity': 3.972.26
       '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
@@ -3107,20 +3107,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.22':
+  '@aws-sdk/credential-provider-process@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.24':
+  '@aws-sdk/credential-provider-sso@3.972.26':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/nested-clients': 3.996.14
-      '@aws-sdk/token-providers': 3.1015.0
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.16
+      '@aws-sdk/token-providers': 3.1019.0
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -3129,10 +3129,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.24':
+  '@aws-sdk/credential-provider-web-identity@3.972.26':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/nested-clients': 3.996.14
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.16
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -3154,7 +3154,7 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.8':
+  '@aws-sdk/middleware-recursion-detection@3.972.9':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@aws/lambda-invoke-store': 0.2.4
@@ -3162,9 +3162,9 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.25':
+  '@aws-sdk/middleware-user-agent@3.972.26':
     dependencies:
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@smithy/core': 3.23.12
@@ -3173,20 +3173,20 @@ snapshots:
       '@smithy/util-retry': 4.2.12
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.996.14':
+  '@aws-sdk/nested-clients@3.996.16':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.25
-      '@aws-sdk/region-config-resolver': 3.972.9
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.26
+      '@aws-sdk/region-config-resolver': 3.972.10
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.11
+      '@aws-sdk/util-user-agent-node': 3.973.12
       '@smithy/config-resolver': 4.4.13
       '@smithy/core': 3.23.12
       '@smithy/fetch-http-handler': 5.3.15
@@ -3216,7 +3216,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.9':
+  '@aws-sdk/region-config-resolver@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@smithy/config-resolver': 4.4.13
@@ -3224,10 +3224,10 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1015.0':
+  '@aws-sdk/token-providers@3.1019.0':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/nested-clients': 3.996.14
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.16
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -3260,16 +3260,16 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.11':
+  '@aws-sdk/util-user-agent-node@3.973.12':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.25
+      '@aws-sdk/middleware-user-agent': 3.972.26
       '@aws-sdk/types': 3.973.6
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.15':
+  '@aws-sdk/xml-builder@3.972.16':
     dependencies:
       '@smithy/types': 4.13.1
       fast-xml-parser: 5.5.8
@@ -4554,14 +4554,14 @@ snapshots:
       '@scure/bip32': 2.0.1
       '@scure/bip39': 2.0.1
       '@wopr-network/platform-crypto-server': 1.1.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(postgres@3.4.8)(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.47.4(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.47.6(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@wopr-network/platform-core@1.71.0(@aws-sdk/client-ses@3.1015.0)(@trpc/server@11.13.4(typescript@5.9.3))(@wopr-network/platform-crypto-server@1.1.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(postgres@3.4.8)(typescript@5.9.3)(zod@4.3.6))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)':
+  '@wopr-network/platform-core@1.74.0(@aws-sdk/client-ses@3.1015.0)(@trpc/server@11.13.4(typescript@5.9.3))(@wopr-network/platform-crypto-server@1.1.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(postgres@3.4.8)(typescript@5.9.3)(zod@4.3.6))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(mongodb@7.1.0)(pg@8.20.0)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(tsx@4.21.0)(yaml@2.8.2)))(dockerode@4.0.9)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8))(hono@4.12.5)(pg@8.20.0)(resend@6.9.3)(stripe@18.5.0(@types/node@25.3.5))(typescript@5.9.3)(ws@8.18.3)(zod@4.3.6)':
     dependencies:
       '@aws-sdk/client-ses': 3.1015.0
       '@hono/node-server': 1.19.11(hono@4.12.5)
@@ -4582,7 +4582,7 @@ snapshots:
       postmark: 4.0.7
       resend: 6.9.3
       stripe: 18.5.0(@types/node@25.3.5)
-      viem: 2.47.4(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.47.6(typescript@5.9.3)(zod@4.3.6)
       ws: 8.18.3
       yaml: 2.8.2
       zod: 4.3.6

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -237,6 +237,13 @@ export class Engine {
       return { gated: true, ...routing, terminal: false };
     }
 
+    // Persist gate-extracted artifacts (e.g., spec body, PR metadata)
+    if (routing.artifacts && Object.keys(routing.artifacts).length > 0) {
+      await entityRepo.updateArtifacts(entityId, routing.artifacts);
+      const refreshed = await entityRepo.get(entityId);
+      if (refreshed) entity = refreshed;
+    }
+
     // Gate passed or redirected — determine the actual destination.
     let toState = routing.kind === "redirect" ? routing.toState : transition.toState;
     const trigger = routing.kind === "redirect" ? routing.trigger : signal;
@@ -463,8 +470,8 @@ export class Engine {
     flow: Flow,
     txRepos?: TransactionRepos | null,
   ): Promise<
-    | { kind: "proceed"; gatesPassed: string[] }
-    | { kind: "redirect"; toState: string; trigger: string; gatesPassed: string[] }
+    | { kind: "proceed"; gatesPassed: string[]; artifacts?: Record<string, unknown> }
+    | { kind: "redirect"; toState: string; trigger: string; gatesPassed: string[]; artifacts?: Record<string, unknown> }
     | {
         kind: "block";
         gateTimedOut: boolean;
@@ -537,6 +544,7 @@ export class Engine {
         toState: namedOutcome.toState,
         trigger: `gate:${gate.name}:${outcomeLabel}`,
         gatesPassed: [gate.name],
+        artifacts: gateResult.artifacts,
       };
     }
 
@@ -548,7 +556,7 @@ export class Engine {
         gateId: gate.id,
         emittedAt: new Date(),
       });
-      return { kind: "proceed", gatesPassed: [gate.name] };
+      return { kind: "proceed", gatesPassed: [gate.name], artifacts: gateResult.artifacts };
     }
 
     // Gate failed — persist failure context and emit event

--- a/src/engine/gate-evaluator.ts
+++ b/src/engine/gate-evaluator.ts
@@ -16,6 +16,8 @@ export interface GateEvalResult {
   outcome?: string;
   /** Human-readable message from structured JSON output. */
   message?: string;
+  /** Artifacts extracted by the gate op (e.g., comment body, PR metadata). */
+  artifacts?: Record<string, unknown>;
 }
 
 /**
@@ -26,7 +28,7 @@ export type PrimitiveOpHandler = (
   primitiveOp: string,
   primitiveParams: Record<string, unknown>,
   entity: Entity,
-) => Promise<{ outcome: string; message?: string }>;
+) => Promise<{ outcome: string; message?: string; artifacts?: Record<string, unknown> }>;
 
 // Anchor path-traversal checks to the project root. realpathSync resolves symlinks
 // so the containment check works even when the project directory itself is a symlink.
@@ -91,7 +93,7 @@ export async function evaluateGate(
       passed = outcomeConfig?.proceed === true;
       output = message;
       await gateRepo.record(entity.id, gate.id, passed, output);
-      return { passed, timedOut: false, output, outcome, message };
+      return { passed, timedOut: false, output, outcome, message, artifacts: opResult.artifacts };
     } catch (err) {
       const msg = `Primitive gate error: ${err instanceof Error ? err.message : String(err)}`;
       await gateRepo.record(entity.id, gate.id, false, msg);

--- a/src/flows/engineering.ts
+++ b/src/flows/engineering.ts
@@ -245,11 +245,16 @@ export const GATES: CreateGateInput[] = [
     primitiveParams: {
       issueNumber: "{{entity.artifacts.issueNumber}}",
       pattern: "## Implementation Spec",
+      artifactKey: "architectSpec",
     },
     timeoutMs: 120_000,
     failurePrompt:
       "The spec gate checked for a comment starting with '## Implementation Spec' on issue #{{entity.artifacts.issueNumber}} and did not find one. Post the spec as a comment on the issue. The comment MUST start with the exact heading '## Implementation Spec'.",
     timeoutPrompt: "The spec gate timed out after 2 minutes. The GitHub API may be slow. Try posting the spec again.",
+    outcomes: {
+      exists: { proceed: true },
+      not_found: { proceed: false },
+    },
   },
   {
     name: "ci-green",
@@ -283,6 +288,64 @@ export const GATES: CreateGateInput[] = [
       mergeable: { proceed: true },
       blocked: { toState: "fix" },
       closed: { toState: "stuck" },
+    },
+  },
+  {
+    name: "pr-exists",
+    type: "primitive",
+    primitiveOp: "vcs.pr_for_branch",
+    primitiveParams: {
+      branchPattern: "agent/{{entity.id}}/",
+    },
+    timeoutMs: 120_000,
+    failurePrompt: "No PR found from a branch matching the entity pattern. Create a PR from your working branch.",
+    outcomes: {
+      exists: { proceed: true },
+      not_found: { proceed: false },
+    },
+  },
+  {
+    name: "review-status",
+    type: "primitive",
+    primitiveOp: "vcs.pr_review_status",
+    primitiveParams: {
+      pullNumber: "{{entity.artifacts.prNumber}}",
+    },
+    timeoutMs: 300_000,
+    failurePrompt: "Could not determine PR review status for PR #{{entity.artifacts.prNumber}}.",
+    outcomes: {
+      clean: { proceed: true },
+      has_issues: { toState: "fix" },
+    },
+  },
+  {
+    name: "pr-updated",
+    type: "primitive",
+    primitiveOp: "vcs.pr_head_changed",
+    primitiveParams: {
+      pullNumber: "{{entity.artifacts.prNumber}}",
+      lastKnownSha: "{{entity.artifacts.headSha}}",
+    },
+    timeoutMs: 120_000,
+    failurePrompt: "PR head SHA has not changed since last review. Push your fixes to the branch.",
+    outcomes: {
+      changed: { proceed: true },
+      unchanged: { proceed: false },
+    },
+  },
+  {
+    name: "docs-committed",
+    type: "primitive",
+    primitiveOp: "vcs.files_changed_since",
+    primitiveParams: {
+      pullNumber: "{{entity.artifacts.prNumber}}",
+      pathPatterns: "docs/,README*,*.md,CHANGELOG*",
+    },
+    timeoutMs: 120_000,
+    failurePrompt: "No documentation files were changed in the PR. Update docs, README, or add a CHANGELOG entry.",
+    outcomes: {
+      changed: { proceed: true },
+      unchanged: { proceed: false },
     },
   },
 ];
@@ -324,5 +387,9 @@ export const TRANSITIONS: CreateTransitionInput[] = [
 export const GATE_WIRING: Record<string, { fromState: string; trigger: string }> = {
   "spec-posted": { fromState: "spec", trigger: "spec_ready" },
   "ci-green": { fromState: "code", trigger: "pr_created" },
+  "pr-exists": { fromState: "code", trigger: "pr_created" },
+  "review-status": { fromState: "review", trigger: "clean" },
+  "pr-updated": { fromState: "fix", trigger: "fixes_pushed" },
+  "docs-committed": { fromState: "docs", trigger: "docs_ready" },
   "pr-mergeable": { fromState: "merge", trigger: "merged" },
 };

--- a/src/github/primitive-ops.ts
+++ b/src/github/primitive-ops.ts
@@ -35,7 +35,7 @@ export async function checkCiStatus(ctx: GitHubGateContext, params: { ref: strin
     : { outcome: "failed", message: "Some checks failed" };
 }
 
-/** Check PR merge status. */
+/** Check PR merge status. Extracts PR metadata as artifacts. */
 export async function checkPrStatus(ctx: GitHubGateContext, params: { pullNumber: number }): Promise<GateOpResult> {
   const res = await fetch(`https://api.github.com/repos/${ctx.owner}/${ctx.repo}/pulls/${params.pullNumber}`, {
     headers: {
@@ -47,14 +47,22 @@ export async function checkPrStatus(ctx: GitHubGateContext, params: { pullNumber
   if (!res.ok) {
     return { outcome: "error", message: `GitHub API error: ${res.status}` };
   }
-  const pr = (await res.json()) as { merged: boolean; state: string; mergeable_state: string };
-  if (pr.merged) return { outcome: "merged" };
-  if (pr.state === "closed") return { outcome: "closed" };
-  if (pr.mergeable_state === "clean") return { outcome: "mergeable" };
-  return { outcome: "blocked", message: `PR state: ${pr.mergeable_state}` };
+  const pr = (await res.json()) as {
+    merged: boolean;
+    state: string;
+    mergeable_state: string;
+    html_url: string;
+    number: number;
+    head: { sha: string };
+  };
+  const prArtifacts = { prUrl: pr.html_url, prNumber: pr.number, headSha: pr.head.sha };
+  if (pr.merged) return { outcome: "merged", artifacts: prArtifacts };
+  if (pr.state === "closed") return { outcome: "closed", artifacts: prArtifacts };
+  if (pr.mergeable_state === "clean") return { outcome: "mergeable", artifacts: prArtifacts };
+  return { outcome: "blocked", message: `PR state: ${pr.mergeable_state}`, artifacts: prArtifacts };
 }
 
-/** Check if a comment matching a pattern exists on an issue. */
+/** Check if a comment matching a pattern exists on an issue. Extracts the last matching comment body. */
 export async function checkCommentExists(
   ctx: GitHubGateContext,
   params: { issueNumber: number; pattern: string },
@@ -74,8 +82,163 @@ export async function checkCommentExists(
   }
   const comments = (await res.json()) as Array<{ body: string }>;
   const regex = new RegExp(params.pattern);
-  const found = comments.some((c) => regex.test(c.body));
-  return found
-    ? { outcome: "exists", message: "Matching comment found" }
+  const match = comments.filter((c) => regex.test(c.body)).at(-1);
+  return match
+    ? { outcome: "exists", message: "Matching comment found", artifacts: { extractedBody: match.body } }
     : { outcome: "not_found", message: "No matching comment" };
+}
+
+/** Check if an open PR exists from a branch matching the given pattern. */
+export async function checkPrForBranch(
+  ctx: GitHubGateContext,
+  params: { branchPattern: string },
+): Promise<GateOpResult> {
+  const res = await fetch(`https://api.github.com/repos/${ctx.owner}/${ctx.repo}/pulls?state=open&per_page=100`, {
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    return { outcome: "error", message: `GitHub API error: ${res.status}` };
+  }
+  const prs = (await res.json()) as Array<{
+    html_url: string;
+    number: number;
+    head: { ref: string; sha: string };
+  }>;
+  const regex = new RegExp(params.branchPattern);
+  const match = prs.find((pr) => regex.test(pr.head.ref));
+  return match
+    ? {
+        outcome: "exists",
+        message: `PR #${match.number} from branch ${match.head.ref}`,
+        artifacts: {
+          prUrl: match.html_url,
+          prNumber: match.number,
+          headSha: match.head.sha,
+          headBranch: match.head.ref,
+        },
+      }
+    : { outcome: "not_found", message: "No PR found matching branch pattern" };
+}
+
+/** Check PR review status — unresolved comments mean issues remain. */
+export async function checkPrReviewStatus(
+  ctx: GitHubGateContext,
+  params: { pullNumber: number },
+): Promise<GateOpResult> {
+  const [reviewsRes, commentsRes] = await Promise.all([
+    fetch(`https://api.github.com/repos/${ctx.owner}/${ctx.repo}/pulls/${params.pullNumber}/reviews`, {
+      headers: {
+        Authorization: `Bearer ${ctx.token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    }),
+    fetch(`https://api.github.com/repos/${ctx.owner}/${ctx.repo}/issues/${params.pullNumber}/comments?per_page=100`, {
+      headers: {
+        Authorization: `Bearer ${ctx.token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    }),
+  ]);
+
+  if (!reviewsRes.ok || !commentsRes.ok) {
+    return {
+      outcome: "error",
+      message: `GitHub API error: reviews=${reviewsRes.status} comments=${commentsRes.status}`,
+    };
+  }
+
+  const reviews = (await reviewsRes.json()) as Array<{ state: string; user: { login: string }; body: string }>;
+  const comments = (await commentsRes.json()) as Array<{ user: { login: string }; body: string }>;
+
+  const changesRequested = reviews.some((r) => r.state === "CHANGES_REQUESTED");
+
+  const botPatterns = /qodo-code-review|coderabbitai|sourcery-ai|devin-ai/i;
+  const botComments = comments.filter((c) => botPatterns.test(c.user.login));
+  const hasUnresolvedBotFindings = botComments.length > 0;
+
+  const findings = [
+    ...reviews.filter((r) => r.state === "CHANGES_REQUESTED").map((r) => `[${r.user.login}] ${r.body}`),
+    ...botComments.map((c) => `[${c.user.login}] ${c.body}`),
+  ].join("\n\n---\n\n");
+
+  if (changesRequested || hasUnresolvedBotFindings) {
+    return {
+      outcome: "has_issues",
+      message: `PR has ${changesRequested ? "changes requested" : ""}${changesRequested && hasUnresolvedBotFindings ? " and " : ""}${hasUnresolvedBotFindings ? `${botComments.length} bot findings` : ""}`,
+      artifacts: { reviewFindings: findings },
+    };
+  }
+
+  return { outcome: "clean", message: "No unresolved review comments" };
+}
+
+/** Check if PR head SHA differs from a known SHA (detect new pushes). */
+export async function checkPrHeadChanged(
+  ctx: GitHubGateContext,
+  params: { pullNumber: number; lastKnownSha: string },
+): Promise<GateOpResult> {
+  const res = await fetch(`https://api.github.com/repos/${ctx.owner}/${ctx.repo}/pulls/${params.pullNumber}`, {
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    return { outcome: "error", message: `GitHub API error: ${res.status}` };
+  }
+  const pr = (await res.json()) as { head: { sha: string } };
+  if (pr.head.sha !== params.lastKnownSha) {
+    return {
+      outcome: "changed",
+      message: `Head SHA changed: ${params.lastKnownSha.slice(0, 7)} → ${pr.head.sha.slice(0, 7)}`,
+      artifacts: { headSha: pr.head.sha },
+    };
+  }
+  return { outcome: "unchanged", message: "Head SHA has not changed" };
+}
+
+/** Check if files matching path patterns were changed in a PR. */
+export async function checkFilesChangedSince(
+  ctx: GitHubGateContext,
+  params: { pullNumber: number; pathPatterns: string },
+): Promise<GateOpResult> {
+  const res = await fetch(
+    `https://api.github.com/repos/${ctx.owner}/${ctx.repo}/pulls/${params.pullNumber}/files?per_page=100`,
+    {
+      headers: {
+        Authorization: `Bearer ${ctx.token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!res.ok) {
+    return { outcome: "error", message: `GitHub API error: ${res.status}` };
+  }
+  const files = (await res.json()) as Array<{ filename: string; status: string }>;
+  const patterns = params.pathPatterns.split(",").map((p) => p.trim());
+  const matching = files.filter((f) =>
+    patterns.some((pattern) => {
+      if (pattern.endsWith("/")) return f.filename.startsWith(pattern);
+      if (pattern.includes("*")) {
+        const regex = new RegExp(`^${pattern.replace(/\*/g, ".*")}$`);
+        return regex.test(f.filename);
+      }
+      return f.filename === pattern;
+    }),
+  );
+  return matching.length > 0
+    ? {
+        outcome: "changed",
+        message: `${matching.length} matching file(s) changed`,
+        artifacts: { changedFiles: matching.map((f) => f.filename) },
+      }
+    : { outcome: "unchanged", message: "No matching files changed" };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,15 @@ import { EventEmitter } from "./engine/event-emitter.js";
 import type { PrimitiveOpHandler } from "./engine/gate-evaluator.js";
 import { provisionEngineeringFlow } from "./flows/provision.js";
 import { DrizzleGitHubInstallationRepository } from "./github/installation-repo.js";
-import { checkCiStatus, checkCommentExists, checkPrStatus } from "./github/primitive-ops.js";
+import {
+  checkCiStatus,
+  checkCommentExists,
+  checkFilesChangedSince,
+  checkPrForBranch,
+  checkPrHeadChanged,
+  checkPrReviewStatus,
+  checkPrStatus,
+} from "./github/primitive-ops.js";
 import { getInstallationAccessToken } from "./github/token-generator.js";
 import { createGitHubWebhookRoutes } from "./github/webhook.js";
 import { logger } from "./logger.js";
@@ -337,10 +345,34 @@ async function main() {
             return checkCiStatus(ctx, { ref: params.ref as string });
           case "vcs.pr_status":
             return checkPrStatus(ctx, { pullNumber: Number(params.pullNumber) });
-          case "issue_tracker.comment_exists":
-            return checkCommentExists(ctx, {
+          case "issue_tracker.comment_exists": {
+            const result = await checkCommentExists(ctx, {
               issueNumber: Number(params.issueNumber),
               pattern: params.pattern as string,
+            });
+            const artifactKey = params.artifactKey as string | undefined;
+            if (artifactKey && result.artifacts) {
+              const arts = result.artifacts as Record<string, unknown>;
+              if (arts.extractedBody) {
+                arts[artifactKey] = arts.extractedBody;
+                delete arts.extractedBody;
+              }
+            }
+            return result;
+          }
+          case "vcs.pr_for_branch":
+            return checkPrForBranch(ctx, { branchPattern: params.branchPattern as string });
+          case "vcs.pr_review_status":
+            return checkPrReviewStatus(ctx, { pullNumber: Number(params.pullNumber) });
+          case "vcs.pr_head_changed":
+            return checkPrHeadChanged(ctx, {
+              pullNumber: Number(params.pullNumber),
+              lastKnownSha: params.lastKnownSha as string,
+            });
+          case "vcs.files_changed_since":
+            return checkFilesChangedSince(ctx, {
+              pullNumber: Number(params.pullNumber),
+              pathPatterns: params.pathPatterns as string,
             });
           default:
             return { outcome: "error", message: `Unknown primitive op: ${primitiveOp}` };

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,9 +114,11 @@ async function main() {
   // ─── 4. BetterAuth init ───────────────────────────────────────────────
   const { initBetterAuth, runAuthMigrations } = await import("@wopr-network/platform-core/auth/better-auth");
   const { grantSignupCredits } = await import("@wopr-network/platform-core/credits");
+  const productDomain = container.productConfig.product?.domain;
   initBetterAuth({
     pool: container.pool,
     db: platformDb,
+    cookieDomain: productDomain ? `.${productDomain}` : undefined,
     onUserCreated: async (userId: string) => {
       try {
         const granted = await grantSignupCredits(container.creditLedger, userId);

--- a/tests/engine/gate-artifact-extraction.test.ts
+++ b/tests/engine/gate-artifact-extraction.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import type { GateEvalResult } from "../../src/engine/gate-evaluator.js";
+
+describe("Gate artifact extraction contract", () => {
+  it("GateEvalResult can carry artifacts", () => {
+    const result: GateEvalResult = {
+      passed: true,
+      timedOut: false,
+      output: "Matching comment found",
+      outcome: "exists",
+      artifacts: { architectSpec: "## Implementation Spec\n\nThe full spec." },
+    };
+
+    expect(result.artifacts).toBeDefined();
+    expect(result.artifacts!.architectSpec).toContain("## Implementation Spec");
+  });
+
+  it("GateEvalResult without artifacts is backward-compatible", () => {
+    const result: GateEvalResult = {
+      passed: true,
+      timedOut: false,
+      output: "All checks passed",
+      outcome: "passed",
+    };
+
+    expect(result.artifacts).toBeUndefined();
+  });
+
+  it("PR metadata artifacts have expected shape", () => {
+    const result: GateEvalResult = {
+      passed: true,
+      timedOut: false,
+      output: "PR is mergeable",
+      outcome: "mergeable",
+      artifacts: {
+        prUrl: "https://github.com/wopr-network/holyship/pull/42",
+        prNumber: 42,
+        headSha: "abc123def456",
+      },
+    };
+
+    expect(result.artifacts!.prUrl).toMatch(/^https:\/\/github\.com\//);
+    expect(result.artifacts!.prNumber).toBe(42);
+    expect(typeof result.artifacts!.headSha).toBe("string");
+  });
+});

--- a/tests/flows/engineering-flow.test.ts
+++ b/tests/flows/engineering-flow.test.ts
@@ -33,14 +33,23 @@ describe("Engineering flow definition", () => {
     expect(names).toContain("budget_exceeded");
   });
 
-  it("defines 3 opinionated gates", () => {
-    expect(GATES).toHaveLength(3);
+  it("defines 7 gates", () => {
+    expect(GATES).toHaveLength(7);
     const names = GATES.map((g) => g.name);
-    expect(names).toEqual(["spec-posted", "ci-green", "pr-mergeable"]);
+    expect(names).toEqual(["spec-posted", "ci-green", "pr-mergeable", "pr-exists", "review-status", "pr-updated", "docs-committed"]);
   });
 
   it("defines 12 transitions covering full flow graph", () => {
     expect(TRANSITIONS).toHaveLength(12);
+  });
+
+  it("spec-posted gate has outcomes map and artifactKey", () => {
+    const specGate = GATES.find((g) => g.name === "spec-posted");
+    expect(specGate?.outcomes).toEqual({
+      exists: { proceed: true },
+      not_found: { proceed: false },
+    });
+    expect(specGate?.primitiveParams?.artifactKey).toBe("architectSpec");
   });
 
   it("has gate wiring for spec→code, code→review, merge→done", () => {

--- a/tests/github/primitive-ops.test.ts
+++ b/tests/github/primitive-ops.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  checkCommentExists,
+  checkPrStatus,
+  checkPrForBranch,
+  checkPrReviewStatus,
+  checkPrHeadChanged,
+  checkFilesChangedSince,
+} from "../../src/github/primitive-ops.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("checkCommentExists", () => {
+  const ctx = { token: "test-token", owner: "wopr-network", repo: "test-repo" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 'exists' with extracted body when matching comment found", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { body: "Some unrelated comment" },
+        { body: "## Implementation Spec\n\nFull spec text.\n\n### Details\nMore content." },
+      ],
+    });
+
+    const result = await checkCommentExists(ctx, { issueNumber: 42, pattern: "## Implementation Spec" });
+
+    expect(result.outcome).toBe("exists");
+    expect(result.artifacts).toBeDefined();
+    expect(result.artifacts!.extractedBody).toContain("## Implementation Spec");
+    expect(result.artifacts!.extractedBody).toContain("More content.");
+  });
+
+  it("returns 'not_found' with no artifacts when no match", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ body: "Unrelated comment" }],
+    });
+
+    const result = await checkCommentExists(ctx, { issueNumber: 42, pattern: "## Implementation Spec" });
+
+    expect(result.outcome).toBe("not_found");
+    expect(result.artifacts).toBeUndefined();
+  });
+
+  it("returns last matching comment when multiple match", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { body: "## Implementation Spec\n\nOld version" },
+        { body: "## Implementation Spec\n\nNew version" },
+      ],
+    });
+
+    const result = await checkCommentExists(ctx, { issueNumber: 42, pattern: "## Implementation Spec" });
+
+    expect(result.outcome).toBe("exists");
+    expect(result.artifacts!.extractedBody).toContain("New version");
+  });
+
+  it("returns error on API failure", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const result = await checkCommentExists(ctx, { issueNumber: 42, pattern: "## Implementation Spec" });
+
+    expect(result.outcome).toBe("error");
+    expect(result.artifacts).toBeUndefined();
+  });
+});
+
+describe("checkPrStatus", () => {
+  const ctx = { token: "test-token", owner: "wopr-network", repo: "test-repo" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 'mergeable' with PR metadata artifacts", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        merged: false, state: "open", mergeable_state: "clean",
+        html_url: "https://github.com/wopr-network/test-repo/pull/7",
+        number: 7, head: { sha: "abc123def456" },
+      }),
+    });
+
+    const result = await checkPrStatus(ctx, { pullNumber: 7 });
+
+    expect(result.outcome).toBe("mergeable");
+    expect(result.artifacts).toBeDefined();
+    expect(result.artifacts!.prUrl).toBe("https://github.com/wopr-network/test-repo/pull/7");
+    expect(result.artifacts!.prNumber).toBe(7);
+    expect(result.artifacts!.headSha).toBe("abc123def456");
+  });
+
+  it("returns 'merged' with artifacts", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        merged: true, state: "closed", mergeable_state: "unknown",
+        html_url: "https://github.com/wopr-network/test-repo/pull/7",
+        number: 7, head: { sha: "abc123" },
+      }),
+    });
+
+    const result = await checkPrStatus(ctx, { pullNumber: 7 });
+
+    expect(result.outcome).toBe("merged");
+    expect(result.artifacts!.prUrl).toBe("https://github.com/wopr-network/test-repo/pull/7");
+  });
+
+  it("returns 'blocked' with artifacts and message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        merged: false, state: "open", mergeable_state: "blocked",
+        html_url: "https://github.com/wopr-network/test-repo/pull/7",
+        number: 7, head: { sha: "abc123" },
+      }),
+    });
+
+    const result = await checkPrStatus(ctx, { pullNumber: 7 });
+
+    expect(result.outcome).toBe("blocked");
+    expect(result.artifacts!.headSha).toBe("abc123");
+  });
+
+  it("returns error without artifacts on API failure", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const result = await checkPrStatus(ctx, { pullNumber: 7 });
+
+    expect(result.outcome).toBe("error");
+    expect(result.artifacts).toBeUndefined();
+  });
+});
+
+describe("checkPrForBranch", () => {
+  const ctx = { token: "test-token", owner: "wopr-network", repo: "test-repo" };
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns 'exists' with artifacts when matching PR found", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { html_url: "https://github.com/wopr-network/test-repo/pull/5", number: 5, head: { ref: "feature/unrelated", sha: "aaa" } },
+        { html_url: "https://github.com/wopr-network/test-repo/pull/7", number: 7, head: { ref: "agent/entity-abc/wop-42", sha: "bbb123" } },
+      ],
+    });
+    const result = await checkPrForBranch(ctx, { branchPattern: "agent/entity-abc/" });
+    expect(result.outcome).toBe("exists");
+    expect(result.artifacts!.prNumber).toBe(7);
+    expect(result.artifacts!.headSha).toBe("bbb123");
+    expect(result.artifacts!.headBranch).toBe("agent/entity-abc/wop-42");
+  });
+
+  it("returns 'not_found' when no match", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { html_url: "https://github.com/wopr-network/test-repo/pull/5", number: 5, head: { ref: "feature/unrelated", sha: "aaa" } },
+      ],
+    });
+    const result = await checkPrForBranch(ctx, { branchPattern: "agent/entity-abc/" });
+    expect(result.outcome).toBe("not_found");
+  });
+});
+
+describe("checkPrReviewStatus", () => {
+  const ctx = { token: "test-token", owner: "wopr-network", repo: "test-repo" };
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns 'clean' when no blocking reviews or bot comments", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => [{ state: "APPROVED", user: { login: "human" }, body: "LGTM" }],
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => [{ user: { login: "human-commenter" }, body: "Nice work" }],
+    });
+    const result = await checkPrReviewStatus(ctx, { pullNumber: 7 });
+    expect(result.outcome).toBe("clean");
+  });
+
+  it("returns 'has_issues' with findings when changes requested", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => [{ state: "CHANGES_REQUESTED", user: { login: "reviewer" }, body: "Fix the null check" }],
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => [],
+    });
+    const result = await checkPrReviewStatus(ctx, { pullNumber: 7 });
+    expect(result.outcome).toBe("has_issues");
+    expect(result.artifacts!.reviewFindings).toContain("Fix the null check");
+  });
+
+  it("returns 'has_issues' when bot comments exist", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => [],
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => [{ user: { login: "coderabbitai[bot]" }, body: "Security: SQL injection risk" }],
+    });
+    const result = await checkPrReviewStatus(ctx, { pullNumber: 7 });
+    expect(result.outcome).toBe("has_issues");
+    expect(result.artifacts!.reviewFindings).toContain("SQL injection");
+  });
+});
+
+describe("checkPrHeadChanged", () => {
+  const ctx = { token: "test-token", owner: "wopr-network", repo: "test-repo" };
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns 'changed' with new SHA when head differs", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ head: { sha: "new-sha-456" } }),
+    });
+    const result = await checkPrHeadChanged(ctx, { pullNumber: 7, lastKnownSha: "old-sha-123" });
+    expect(result.outcome).toBe("changed");
+    expect(result.artifacts!.headSha).toBe("new-sha-456");
+  });
+
+  it("returns 'unchanged' when SHA matches", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ head: { sha: "same-sha" } }),
+    });
+    const result = await checkPrHeadChanged(ctx, { pullNumber: 7, lastKnownSha: "same-sha" });
+    expect(result.outcome).toBe("unchanged");
+  });
+});
+
+describe("checkFilesChangedSince", () => {
+  const ctx = { token: "test-token", owner: "wopr-network", repo: "test-repo" };
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns 'changed' when matching files found", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => [
+        { filename: "src/main.ts", status: "modified" },
+        { filename: "docs/api.md", status: "added" },
+        { filename: "README.md", status: "modified" },
+      ],
+    });
+    const result = await checkFilesChangedSince(ctx, { pullNumber: 7, pathPatterns: "docs/,README*" });
+    expect(result.outcome).toBe("changed");
+    expect(result.artifacts!.changedFiles).toEqual(["docs/api.md", "README.md"]);
+  });
+
+  it("returns 'unchanged' when no matching files", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => [
+        { filename: "src/main.ts", status: "modified" },
+        { filename: "src/utils.ts", status: "added" },
+      ],
+    });
+    const result = await checkFilesChangedSince(ctx, { pullNumber: 7, pathPatterns: "docs/,README*" });
+    expect(result.outcome).toBe("unchanged");
+  });
+});


### PR DESCRIPTION
## Summary

- Gates now return extracted artifacts alongside routing outcomes
- `checkCommentExists` extracts matched comment body (last match wins)
- `checkPrStatus` extracts PR metadata (url, number, headSha)
- Engine persists gate artifacts to entity before state transition
- `spec-posted` gate maps extracted comment body to `architectSpec` artifact via `artifactKey` param

This closes the artifact handoff gap: spec agent posts to GitHub, gate verifies AND extracts the comment body, `entity.artifacts.architectSpec` is populated before the coder's prompt template renders.

Implements Phase 1 of #266 (gate-driven signals).

## Test plan

- [ ] `npx vitest run tests/github/primitive-ops.test.ts` — 8 tests for comment extraction + PR metadata extraction
- [ ] `npx vitest run tests/engine/gate-artifact-extraction.test.ts` — 3 contract tests for GateEvalResult artifacts
- [ ] `npx vitest run tests/flows/engineering-flow.test.ts` — 29 tests including new spec-posted outcomes map test
- [ ] `npm run check` — biome + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add gate artifact extraction so GitHub primitive ops and gate evaluations can return and persist artifacts on entities before state transitions.

New Features:
- Allow gate primitive operations and gate evaluations to return optional artifacts alongside outcomes.
- Extract the last matching GitHub issue comment body and map it into a named artifact for the engineering spec gate.
- Capture GitHub PR metadata (URL, number, head SHA) as artifacts during PR status checks.
- Configure BetterAuth to use a product-specific cookie domain when available.

Enhancements:
- Propagate gate artifacts through gate resolution and engine routing, persisting them on the entity prior to transitioning state.
- Extend the engineering spec-posted gate with explicit outcomes and artifact wiring to support architect spec handoff.
- Document the gate artifact extraction implementation plan and gate-driven signals design for future phases.

Build:
- Update the @wopr-network/platform-core dependency to a newer version.

Documentation:
- Add a detailed implementation plan for gate artifact extraction and a design spec for gate-driven signals to the docs.

Tests:
- Add unit tests for GitHub primitive operations to verify comment body and PR metadata extraction and error handling.
- Add tests for the engineering flow to assert spec-posted gate outcomes and artifact configuration.
- Add engine-level contract tests validating that GateEvalResult supports artifacts for downstream use.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add gate artifact extraction to the engine with new GitHub primitive ops
> - Extends `GateEvalResult` and `PrimitiveOpHandler` in [gate-evaluator.ts](https://github.com/wopr-network/holyship/pull/267/files#diff-2fbba9489ac39de7e98310890772c5fbfce792a6bef32e5a728095adb709c937) to carry an optional `artifacts` field, and updates `Engine._processSignalInner` to persist those artifacts to the entity via `entityRepo.updateArtifacts` after gate resolution.
> - Adds four new GitHub primitive ops in [primitive-ops.ts](https://github.com/wopr-network/holyship/pull/267/files#diff-013b43c0a36261206d553a47e42152dc02a2711eae22176ce596a5e911870df8): `checkPrForBranch`, `checkPrReviewStatus`, `checkPrHeadChanged`, and `checkFilesChangedSince`, and extends existing ops (`checkPrStatus`, `checkCommentExists`) to return metadata artifacts.
> - Wires the new ops into the `primitiveOpHandler` switch in [index.ts](https://github.com/wopr-network/holyship/pull/267/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) as `vcs.pr_for_branch`, `vcs.pr_review_status`, `vcs.pr_head_changed`, and `vcs.files_changed_since`, with artifact key remapping for `issue_tracker.comment_exists`.
> - Extends the engineering flow in [engineering.ts](https://github.com/wopr-network/holyship/pull/267/files#diff-120145a716638874d8a06b2a6a66701396d46349df31e11007998f75b71d83ed) with four new primitive gates (`pr-exists`, `review-status`, `pr-updated`, `docs-committed`) and outcome wiring for code, review, fix, and docs states.
> - Bumps `@wopr-network/platform-core` from `^1.71.0` to `^1.74.0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b6e69e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gates now extract and persist metadata artifacts from external checks (e.g., PR and comment metadata) and use them to drive transitions.
  * New VCS-driven gates added to guard engineering flow transitions (PR existence, review status, head changes, docs changes).

* **Documentation**
  * Added design spec for gate-driven signals workflow.
  * Added phase-1 and phase-2 implementation plans for artifact extraction and new primitive ops.

* **Tests**
  * Added unit and integration tests validating artifact extraction, shapes, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->